### PR TITLE
Add missing buttons to mecool remote

### DIFF
--- a/packages/sysutils/v4l-utils/keymaps/mecool
+++ b/packages/sysutils/v4l-utils/keymaps/mecool
@@ -41,3 +41,5 @@
 0x01 KEY_LANGUAGE      # audio
 0x09 KEY_SUBTITLE      # subtitle
 0x12 KEY_CONTEXT_MENU  # mouse
+0x22 KEY_TAB
+0x18 KEY_I


### PR DESCRIPTION
Following the procedure described [here](https://forum.libreelec.tv/thread/11643-le9-0-remote-configs-ir-keytable-amlogic-devices/?pageNo=1) for a meccol remote control ([this](https://img.sunsky-online.com/upload/store/detail_l/EAT0420_7.jpg)) I found some buttons missing from the built-in config:
0x22 is the bottom left button, left from '0' and 
0x18 is the 'browser' button, the one with an 'e' on it.
Not sure about the commands I assigned, couldn't think of something better.