### PR TITLE
config/packages: remove os.libreelec dependency

### DIFF
--- a/config/addon/xbmc.broken.xml
+++ b/config/addon/xbmc.broken.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="@PROVIDER_NAME@">
   <requires>
-    <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
     <import addon="xbmc.python" version="2.1.0"/>
 @REQUIRES@
   </requires>

--- a/config/addon/xbmc.python.module.xml
+++ b/config/addon/xbmc.python.module.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="@PROVIDER_NAME@">
   <requires>
-    <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
     <import addon="xbmc.python" version="2.1.0"/>
 @REQUIRES@
   </requires>

--- a/config/addon/xbmc.python.script.xml
+++ b/config/addon/xbmc.python.script.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="@PROVIDER_NAME@">
   <requires>
-    <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
     <import addon="xbmc.python" version="2.1.0"/>
 @REQUIRES@
   </requires>

--- a/config/addon/xbmc.service.library.xml
+++ b/config/addon/xbmc.service.library.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="@PROVIDER_NAME@">
   <requires>
-    <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
     <import addon="xbmc.python" version="2.1.0"/>
 @REQUIRES@
   </requires>

--- a/config/addon/xbmc.service.pluginsource.xml
+++ b/config/addon/xbmc.service.pluginsource.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="@PROVIDER_NAME@">
   <requires>
-    <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
     <import addon="xbmc.python" version="2.1.0"/>
 @REQUIRES@
   </requires>

--- a/config/addon/xbmc.service.xml
+++ b/config/addon/xbmc.service.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="@PROVIDER_NAME@">
   <requires>
-    <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
     <import addon="xbmc.python" version="2.1.0"/>
 @REQUIRES@
   </requires>

--- a/packages/addons/script/script.config.vdr/sources/addon.xml
+++ b/packages/addons/script/script.config.vdr/sources/addon.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="libreelec.tv">
    <requires>
-     <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
      <import addon="xbmc.python" version="2.1.0"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="default.py">

--- a/packages/addons/service/touchscreen/addon.xml
+++ b/packages/addons/service/touchscreen/addon.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="@PROVIDER_NAME@">
   <requires>
-    <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
     <import addon="xbmc.python" version="2.1.0"/>
 @REQUIRES@
   </requires>

--- a/packages/addons/service/tvheadend42/addon.xml
+++ b/packages/addons/service/tvheadend42/addon.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="@PROVIDER_NAME@">
   <requires>
-    <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
     <import addon="xbmc.python" version="2.1.0"/>
 @REQUIRES@
   </requires>

--- a/packages/addons/service/tvheadend44/addon.xml
+++ b/packages/addons/service/tvheadend44/addon.xml
@@ -4,7 +4,6 @@
        version="@ADDON_VERSION@"
        provider-name="@PROVIDER_NAME@">
   <requires>
-    <import addon="os.libreelec.tv" version="@OS_VERSION@"/>
     <import addon="xbmc.python" version="2.1.0"/>
 @REQUIRES@
   </requires>


### PR DESCRIPTION
There is a bug within Kodi that seems to not recognize the os.libreelec.tv dependency within addon's even though it exists on the system.

This gives the false impression to the users that they are missing a dependency when they are not.