### PR TITLE
linux/amlogic: don't copy multi-DTB for S9xx

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -245,7 +245,9 @@ makeinstall_target() {
   if [ "$BOOTLOADER" = "u-boot" ]; then
     mkdir -p $INSTALL/usr/share/bootloader
     if [ -d arch/$TARGET_KERNEL_ARCH/boot/dts/amlogic -a -f arch/$TARGET_KERNEL_ARCH/boot/dtb.img ]; then
-      cp arch/$TARGET_KERNEL_ARCH/boot/dtb.img $INSTALL/usr/share/bootloader/dtb.img 2>/dev/null || :
+      if [ "$DEVICE" != "S905" -a "$DEVICE" != "S912" ]; then
+        cp arch/$TARGET_KERNEL_ARCH/boot/dtb.img $INSTALL/usr/share/bootloader/dtb.img 2>/dev/null || :
+      fi
     else
       for dtb in arch/$TARGET_KERNEL_ARCH/boot/dts/*.dtb arch/$TARGET_KERNEL_ARCH/boot/dts/*/*.dtb; do
         if [ -f $dtb ]; then


### PR DESCRIPTION
There is a scenario where new users fail to read the complete install instructions and ignore install steps regarding the DTB.

As we copy a multi-DTB to the root of our img.gz, some users assume that everything is okay because their box boots up and displays CoreELEC.

Some time later they experience problems, ie no network access and post on the forums https://discourse.coreelec.org/t/no-ssh-access-on-ce-8-90-2-installed-on-nand/381

This is not the first, second or even third time I have seen this happen.

This PR removes the multi-DTB from our S905/S912 images, it may need refining more but testing has shown it has the desired effect with no adverse effect on other device images.