### PR TITLE
Change default kodi resolution to 1080p

### DIFF
--- a/packages/mediacenter/kodi/patches/amlogic/kodi-ce-105-default-kodi-resolution.patch
+++ b/packages/mediacenter/kodi/patches/amlogic/kodi-ce-105-default-kodi-resolution.patch
@@ -1,0 +1,25 @@
+From a0ce8576a44e5e70689384013617c5941af1eddb Mon Sep 17 00:00:00 2001
+From: Dmitry_L <freebox_2002@mail.ru>
+Date: Sat, 9 Jun 2018 11:39:28 +0300
+Subject: [PATCH] Default resolution change to 1080p
+
+If we get nothing we set resolution to 1080p instead of 720p
+---
+ xbmc/utils/AMLUtils.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/xbmc/utils/AMLUtils.cpp b/xbmc/utils/AMLUtils.cpp
+index beb4cbbb6679..aae0589cb07a 100644
+--- a/xbmc/utils/AMLUtils.cpp
++++ b/xbmc/utils/AMLUtils.cpp
+@@ -544,8 +544,8 @@ bool aml_get_preferred_resolution(RESOLUTION_INFO *res)
+   // check display/mode, it gets defaulted at boot
+   if (!aml_get_native_resolution(res))
+   {
+-    // punt to 720p if we get nothing
+-    aml_mode_to_resolution("720p", res);
++    // punt to 1080p if we get nothing
++    aml_mode_to_resolution("1080p", res);
+   }
+ 
+   return true;


### PR DESCRIPTION
Sometimes after reboot or power on kodi didn't receive resolutions from TV and set it by default to 720p.
After this change default resolution is 1080p