### PR TITLE
openssl: move ssl certificate file to /storage/.config/cacert.pem

### DIFF
--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -108,8 +108,11 @@ post_makeinstall_target() {
   debug_strip $INSTALL/usr/bin/openssl
 
   # cert from https://curl.haxx.se/docs/caextract.html
+  mkdir -p $INSTALL/usr/config
+    cp $PKG_DIR/cert/cacert.pem $INSTALL/usr/config
+
   mkdir -p $INSTALL/etc/ssl
-    cp $PKG_DIR/cert/cacert.pem $INSTALL/etc/ssl/cert.pem
+    ln -sf /storage/.config/cacert.pem $INSTALL/etc/ssl/cacert.pem
 
   # backwards comatibility
   mkdir -p $INSTALL/etc/pki/tls


### PR DESCRIPTION
This PR is an alternative to #125 and moves the SSL certificate file to /storage/.config/cacert.pem so a user can modify it and add their own self-signed CA.