### PR TITLE
rpcgen command moved from libc package to rpcsvc-proto in ArchLinux

### DIFF
--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -87,8 +87,8 @@ case "$DISTRO" in
       perl_pkg=(JSON XML-Parser)
       ;;
     arch|manjaro)
-      deps+=(g++ mkfontscale mkfontdir bdftopcf xsltproc java python)
-      deps_pkg+=(g++ xorg-mkfontscale xorg-mkfontdir xorg-bdftopcf libxslt "java-runtime-common jdk8-openjdk" python2)
+      deps+=(g++ mkfontscale mkfontdir bdftopcf xsltproc java python rpcgen)
+      deps_pkg+=(g++ xorg-mkfontscale xorg-mkfontdir xorg-bdftopcf libxslt "java-runtime-common jdk8-openjdk" python2 rpcsvc-proto)
       perl_pkg=(perl-json perl-xml-parser)
       ;;
     opensuse)


### PR DESCRIPTION
Today I've created a new ArchLinux virtual machine from scratch and I've found that rpcgen command moved out from libc package to rpcsvc-proto package. I've created a simple commit to reflect that change and request the package during checkdeps.