### PR TITLE
busybox: erase Kodi package cache on update

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -477,6 +477,17 @@
     umount /sysroot
   }
 
+  erase_kodi_package_cache() {
+    local result
+
+    if [ -d "/storage/.kodi/addons/packages" ]; then
+      StartProgress spinner "Erasing Kodi package cache... "
+        result="$(rm -rf /storage/.kodi/addons/packages 2>&1)"
+        StopProgress "done"
+      echo "${result}"
+    fi
+   }
+
   load_modules() {
     progress "Loading kernel modules"
 
@@ -1019,6 +1030,7 @@
     fi
     update_file "System" "$UPDATE_SYSTEM" "/flash/$IMAGE_SYSTEM"
     update_bootloader
+    erase_kodi_package_cache
     do_cleanup
     do_reboot
   }


### PR DESCRIPTION
This PR erases the Kodi package cache if it exists following a successful update.

Problem scenario:
a user manually updates a package on their device from our repository
said package has not had it's version bumped in the repository
said package has been previously downloaded so the device will not download the updated version

this can also be resolved by bumping PKG_REV but this would make merging LE updates problematic

Summary:
no solution is perfect here but this PR gives users 1 less step to do when we ask them update an addon manually