### PR TITLE
Return auto switching cs/cd

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -24,8 +24,8 @@ case "$LINUX" in
     PKG_BUILD_PERF="no"
     ;;
   amlogic-3.14)
-    PKG_VERSION="d51bd2066498934fa9884d456e57373203f51068"
-    PKG_SHA256="cdbfd86b6c52173bea428b5e1d72d7a71658e7764e7443ca1e216434ae3b53d8"
+    PKG_VERSION="7580f9adfa9212782be274ecad6a11738fd12e38"
+    PKG_SHA256="1b4bf258dc19226feea3009d5ed3b8d3e747a99531b6a6c34ea7014cb941b6ca"
     PKG_URL="https://github.com/CoreELEC/linux-amlogic/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_NAME="linux-$LINUX-$PKG_VERSION.tar.gz"
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET aml-dtbtools:host"

--- a/packages/mediacenter/kodi/patches/amlogic/kodi-ce-114-tmp-restore-async-resolution-change.patch
+++ b/packages/mediacenter/kodi/patches/amlogic/kodi-ce-114-tmp-restore-async-resolution-change.patch
@@ -1,0 +1,28 @@
+From 3907ac1a259a944cb34bc13121cf2e10bb842041 Mon Sep 17 00:00:00 2001
+From: cdu13a <cdu13a@gmail.com>
+Date: Wed, 14 Nov 2018 15:41:47 -0500
+Subject: Revert "[VideoPlayer] SetResolution synchronously instead
+ RM::TriggerResolution"
+
+This reverts commit 062ae33446d01027ed6369cdc54bce9f151c7dea.
+---
+ xbmc/cores/VideoPlayer/VideoPlayer.cpp | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoPlayer.cpp b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+index e2a9319abb..5fa610cceb 100644
+--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
++++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+@@ -3747,8 +3747,6 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
+     if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF)
+     {
+       double framerate = DVD_TIME_BASE / CDVDCodecUtils::NormalizeFrameduration((double)DVD_TIME_BASE * hint.fpsscale / hint.fpsrate);
+-      RESOLUTION res = CResolutionUtils::ChooseBestResolution(static_cast<float>(framerate), hint.width, hint.height, !hint.stereo_mode.empty());
+-      CServiceBroker::GetWinSystem()->GetGfxContext().SetVideoResolution(res, false);
+       m_renderManager.TriggerUpdateResolution(framerate, hint.width, hint.height, hint.stereo_mode);
+     }
+   }
+ 
+-- 
+2.17.1
+

--- a/packages/mediacenter/kodi/patches/amlogic/kodi-le-059-frame-rate-fix-for-interlaced.patch
+++ b/packages/mediacenter/kodi/patches/amlogic/kodi-le-059-frame-rate-fix-for-interlaced.patch
@@ -33,7 +33,7 @@ index 3013773..b68de35 100644
 +        m_processInfo->SetVideoInterlaced(true);
 +      }
 +      m_processInfo->SetVideoFps(static_cast<float>(framerate));
-       m_renderManager.TriggerUpdateResolution(static_cast<float>(framerate), hint.width, hint.stereo_mode);
+       m_renderManager.TriggerUpdateResolution(framerate, hint.width, hint.height, hint.stereo_mode);
      }
    }
 diff --git a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -89,7 +89,7 @@ index 8d23761..3abec20 100644
 +      {
 +        m_processInfo.SetVideoFps(m_processInfo.GetVideoFps() / 2.0f);
 +        m_processInfo.SetVideoInterlaced(false);
-+        m_renderManager.TriggerUpdateResolution(m_processInfo.GetVideoFps() / 2.0f, m_hints.width, m_hints.stereo_mode);
++        m_renderManager.TriggerUpdateResolution(m_processInfo.GetVideoFps() / 2.0f, m_hints.width, m_hints.height, m_hints.stereo_mode);
 +      }
 +    }
 +    else

--- a/packages/mediacenter/kodi/patches/amlogic/kodi-le-059-frame-rate-fix-for-interlaced.patch
+++ b/packages/mediacenter/kodi/patches/amlogic/kodi-le-059-frame-rate-fix-for-interlaced.patch
@@ -1,8 +1,8 @@
 diff --git a/xbmc/cores/VideoPlayer/VideoPlayer.cpp b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
-index e2a9319..03d5535 100644
+index 3013773..b68de35 100644
 --- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
-@@ -63,6 +63,7 @@
+@@ -74,6 +74,7 @@
  #include "Util.h"
  #include "LangInfo.h"
  #include "URL.h"
@@ -10,7 +10,7 @@ index e2a9319..03d5535 100644
  
  
  #ifdef TARGET_RASPBERRY_PI
-@@ -3693,6 +3694,7 @@ bool CVideoPlayer::OpenAudioStream(CDVDStreamInfo& hint, bool reset)
+@@ -3681,6 +3682,7 @@ bool CVideoPlayer::OpenAudioStream(CDVDStreamInfo& hint, bool reset)
  
  bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
  {
@@ -18,8 +18,8 @@ index e2a9319..03d5535 100644
    if (m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
    {
      /* set aspect ratio as requested by navigator for dvd's */
-@@ -3747,6 +3749,17 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
-     if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF)
+@@ -3735,6 +3737,17 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
+     if (CServiceBroker::GetSettingsComponent()->GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF)
      {
        double framerate = DVD_TIME_BASE / CDVDCodecUtils::NormalizeFrameduration((double)DVD_TIME_BASE * hint.fpsscale / hint.fpsrate);
 +      if (MathUtils::FloatEquals(25.0f, static_cast<float>(framerate), 0.01f))
@@ -36,11 +36,12 @@ index e2a9319..03d5535 100644
        RESOLUTION res = CResolutionUtils::ChooseBestResolution(static_cast<float>(framerate), hint.width, hint.height, !hint.stereo_mode.empty());
        CServiceBroker::GetWinSystem()->GetGfxContext().SetVideoResolution(res, false);
      }
+   }
 diff --git a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
-index 4f057e6..1517d22 100644
+index 8d23761..3abec20 100644
 --- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
-@@ -161,11 +161,24 @@ void CVideoPlayerVideo::OpenStream(CDVDStreamInfo &hint, CDVDVideoCodec* codec)
+@@ -175,11 +175,24 @@ void CVideoPlayerVideo::OpenStream(CDVDStreamInfo &hint, CDVDVideoCodec* codec)
    {
      m_fFrameRate = DVD_TIME_BASE / CDVDCodecUtils::NormalizeFrameduration((double)DVD_TIME_BASE * hint.fpsscale / hint.fpsrate);
      m_bFpsInvalid = false;
@@ -66,7 +67,7 @@ index 4f057e6..1517d22 100644
      m_bFpsInvalid = true;
      m_processInfo.SetVideoFps(0);
    }
-@@ -178,8 +191,9 @@ void CVideoPlayerVideo::OpenStream(CDVDStreamInfo &hint, CDVDVideoCodec* codec)
+@@ -192,8 +204,9 @@ void CVideoPlayerVideo::OpenStream(CDVDStreamInfo &hint, CDVDVideoCodec* codec)
  
    if( m_fFrameRate > 120 || m_fFrameRate < 5 )
    {
@@ -78,7 +79,7 @@ index 4f057e6..1517d22 100644
    }
  
    // use aspect in stream if available
-@@ -655,6 +669,20 @@ bool CVideoPlayerVideo::ProcessDecoderOutput(double &frametime, double &pts)
+@@ -673,6 +686,19 @@ bool CVideoPlayerVideo::ProcessDecoderOutput(double &frametime, double &pts)
    {
      bool hasTimestamp = true;
  
@@ -89,8 +90,7 @@ index 4f057e6..1517d22 100644
 +      {
 +        m_processInfo.SetVideoFps(m_processInfo.GetVideoFps() / 2.0f);
 +        m_processInfo.SetVideoInterlaced(false);
-+        RESOLUTION res = CResolutionUtils::ChooseBestResolution(m_processInfo.GetVideoFps() / 2.0f, m_hints.width, m_hints.height, !m_hints.stereo_mode.empty());
-+        CServiceBroker::GetWinSystem()->GetGfxContext().SetVideoResolution(res, false);
++        m_renderManager.TriggerUpdateResolution(m_processInfo.GetVideoFps() / 2.0f, m_hints.width, m_hints.stereo_mode);
 +      }
 +    }
 +    else
@@ -100,10 +100,10 @@ index 4f057e6..1517d22 100644
  
      // validate picture timing,
 diff --git a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
-index 689948c..9d739e9 100644
+index 3c1e015..78a64db 100644
 --- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
 +++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
-@@ -103,6 +103,7 @@ protected:
+@@ -118,6 +118,7 @@ protected:
  
    double m_iSubtitleDelay;
  
@@ -111,3 +111,4 @@ index 689948c..9d739e9 100644
    int m_iLateFrames;
    int m_iDroppedFrames;
    int m_iDroppedRequest;
+--

--- a/packages/mediacenter/kodi/patches/amlogic/kodi-le-059-frame-rate-fix-for-interlaced.patch
+++ b/packages/mediacenter/kodi/patches/amlogic/kodi-le-059-frame-rate-fix-for-interlaced.patch
@@ -19,7 +19,7 @@ index 3013773..b68de35 100644
    {
      /* set aspect ratio as requested by navigator for dvd's */
 @@ -3735,6 +3737,17 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
-     if (CServiceBroker::GetSettingsComponent()->GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF)
+     if (CServiceBroker::GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF)
      {
        double framerate = DVD_TIME_BASE / CDVDCodecUtils::NormalizeFrameduration((double)DVD_TIME_BASE * hint.fpsscale / hint.fpsrate);
 +      if (MathUtils::FloatEquals(25.0f, static_cast<float>(framerate), 0.01f))
@@ -33,8 +33,7 @@ index 3013773..b68de35 100644
 +        m_processInfo->SetVideoInterlaced(true);
 +      }
 +      m_processInfo->SetVideoFps(static_cast<float>(framerate));
-       RESOLUTION res = CResolutionUtils::ChooseBestResolution(static_cast<float>(framerate), hint.width, hint.height, !hint.stereo_mode.empty());
-       CServiceBroker::GetWinSystem()->GetGfxContext().SetVideoResolution(res, false);
+       m_renderManager.TriggerUpdateResolution(static_cast<float>(framerate), hint.width, hint.stereo_mode);
      }
    }
 diff --git a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp

--- a/packages/mediacenter/kodi/patches/kodi-ce-002-add-coreelec-settings.patch
+++ b/packages/mediacenter/kodi/patches/kodi-ce-002-add-coreelec-settings.patch
@@ -2,7 +2,7 @@ diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resour
 index 337b4c4..431f313 100644
 --- a/addons/resource.language.en_gb/resources/strings.po
 +++ b/addons/resource.language.en_gb/resources/strings.po
-@@ -8320,7 +8320,42 @@ msgctxt "#14277"
+@@ -8320,7 +8320,52 @@ msgctxt "#14277"
  msgid "Allow remote control from applications on other systems"
  msgstr ""
  
@@ -42,7 +42,17 @@ index 337b4c4..431f313 100644
 +msgid "Enable this to disable deinterlacing. Requires reboot."
 +msgstr ""
 +
-+#empty strings from id 14285 to 14300
++#: system/settings/settings.xml
++msgctxt "#14285"
++msgid "Disable auto colour depth switching"
++msgstr ""
++
++#: system/settings/settings.xml
++msgctxt "#14286"
++msgid "Enable this to disable auto colour depth switching. Requires reboot."
++msgstr ""
++
++#empty strings from id 14287 to 14300
  
  #. pvr "channels" settings group label
  #: system/settings/settings.xml
@@ -50,7 +60,7 @@ diff --git a/system/settings/settings.xml b/system/settings/settings.xml
 index ee11de2..3322edd 100755
 --- a/system/settings/settings.xml
 +++ b/system/settings/settings.xml
-@@ -2995,6 +2995,22 @@
+@@ -2995,6 +2995,28 @@
          </setting>
        </group>
      </category>
@@ -68,6 +78,12 @@ index ee11de2..3322edd 100755
 +          <default>false</default>
 +          <control type="toggle" />
 +        </setting>
++        <setting id="coreelec.amlogic.autocdsw" type="boolean" label="14285" help="14286">
++          <requirement>HAVE_AMCODEC</requirement>
++          <level>3</level>
++          <default>false</default>
++          <control type="toggle" />
++        </setting>
 +      </group>
 +    </category>
      <category id="cache" label="439" help="36399">
@@ -77,12 +93,13 @@ diff --git a/xbmc/settings/Settings.cpp b/xbmc/settings/Settings.cpp
 index 086dcf2..66c9c33 100644
 --- a/xbmc/settings/Settings.cpp
 +++ b/xbmc/settings/Settings.cpp
-@@ -394,6 +394,8 @@ const std::string CSettings::SETTING_EVENTLOG_SHOW = "eventlog.show";
+@@ -394,6 +394,9 @@ const std::string CSettings::SETTING_EVENTLOG_SHOW = "eventlog.show";
  const std::string CSettings::SETTING_MASTERLOCK_LOCKCODE = "masterlock.lockcode";
  const std::string CSettings::SETTING_MASTERLOCK_STARTUPLOCK = "masterlock.startuplock";
  const std::string CSettings::SETTING_MASTERLOCK_MAXRETRIES = "masterlock.maxretries";
 +const std::string CSettings::SETTING_COREELEC_AMLOGIC_DEINTERLACING = "coreelec.amlogic.deinterlacing";
 +const std::string CSettings::SETTING_COREELEC_AMLOGIC_NOISEREDUCTION = "coreelec.amlogic.noisereduction";
++const std::string CSettings::SETTING_COREELEC_AMLOGIC_AUTOCDSW = "coreelec.amlogic.autocdsw";
  const std::string CSettings::SETTING_CACHE_HARDDISK = "cache.harddisk";
  const std::string CSettings::SETTING_CACHEVIDEO_DVDROM = "cachevideo.dvdrom";
  const std::string CSettings::SETTING_CACHEVIDEO_LAN = "cachevideo.lan";
@@ -90,12 +107,13 @@ diff --git a/xbmc/settings/Settings.h b/xbmc/settings/Settings.h
 index 59a3967..e3dca73 100644
 --- a/xbmc/settings/Settings.h
 +++ b/xbmc/settings/Settings.h
-@@ -352,6 +352,8 @@ public:
+@@ -352,6 +352,9 @@ public:
    static const std::string SETTING_MASTERLOCK_LOCKCODE;
    static const std::string SETTING_MASTERLOCK_STARTUPLOCK;
    static const std::string SETTING_MASTERLOCK_MAXRETRIES;
 +  static const std::string SETTING_COREELEC_AMLOGIC_DEINTERLACING;
 +  static const std::string SETTING_COREELEC_AMLOGIC_NOISEREDUCTION;
++  static const std::string SETTING_COREELEC_AMLOGIC_AUTOCDSW;
    static const std::string SETTING_CACHE_HARDDISK;
    static const std::string SETTING_CACHEVIDEO_DVDROM;
    static const std::string SETTING_CACHEVIDEO_LAN;
@@ -103,7 +121,7 @@ diff --git a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp b/xbmc/windowing/amlogi
 index 0637f83..eddf21b 100644
 --- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
 +++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
-@@ -82,6 +82,12 @@ CWinSystemAmlogic::~CWinSystemAmlogic()
+@@ -82,6 +82,18 @@ CWinSystemAmlogic::~CWinSystemAmlogic()
  
  bool CWinSystemAmlogic::InitWindowSystem()
  {
@@ -111,6 +129,12 @@ index 0637f83..eddf21b 100644
 +  {
 +     CLog::Log(LOGDEBUG, "CWinSystemAmlogic::InitWindowSystem -- disabling noise reduction");
 +     SysfsUtils::SetString("/sys/module/di/parameters/nr2_en", "0");
++  }
++
++  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_COREELEC_AMLOGIC_AUTOCDSW))
++  {
++     CLog::Log(LOGDEBUG, "CWinSystemAmlogic::InitWindowSystem -- disabling auto cd switching");
++     SysfsUtils::SetString("/sys/class/video/disable_cdsw", "1");
 +  }
 +
    m_nativeDisplay = EGL_DEFAULT_DISPLAY;


### PR DESCRIPTION
Changes required to support the use of the auto switching cs/cd kernel.

Note: Since the auto switching cs/cd changes haven't been merged in the kernel yet. 
There is no kernel bump in this pr.