### PR TITLE
projects/Amlogic: add support for NanoPi K2

### DIFF
--- a/projects/Amlogic/devices/S905/options
+++ b/projects/Amlogic/devices/S905/options
@@ -27,4 +27,4 @@
     ADDITIONAL_PACKAGES+=" autoscript-amlogic"
 
   # CoreELEC Subdevices
-    SUBDEVICES="KVIM LePotato Odroid_C2"
+    SUBDEVICES="KVIM LePotato Odroid_C2 NanoPi_K2"

--- a/projects/Amlogic/packages/u-boot-NanoPi_K2/package.mk
+++ b/projects/Amlogic/packages/u-boot-NanoPi_K2/package.mk
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2018-present Team CoreELEC (https://coreelec.org)
+
+PKG_NAME="u-boot-NanoPi_K2"
+PKG_SITE="https://www.denx.de/wiki/U-Boot"
+PKG_DEPENDS_TARGET="toolchain gcc-linaro-aarch64-elf:host gcc-linaro-arm-eabi:host"
+PKG_ARCH="arm aarch64"
+PKG_LICENSE="GPL"
+PKG_LONGDESC="Das U-Boot is a cross-platform bootloader for embedded systems."
+
+PKG_VERSION="4ef665ff6c6ff32a480478589ddf1df325c5f04d"
+PKG_SHA256="8df38aef6624a815909ccae294564570d8723a01e4b1589e146ffa013dea14a6"
+PKG_URL="https://github.com/friendlyarm/u-boot/archive/$PKG_VERSION.tar.gz"
+PKG_UBOOT_CONFIG="nanopi-k2_defconfig"
+PKG_TOOLCHAIN="manual"
+
+pre_make_target() {
+  sed -i "s|arm-none-eabi-|arm-eabi-|g" $PKG_BUILD/Makefile $PKG_BUILD/arch/arm/cpu/armv8/gx*/firmware/scp_task/Makefile 2>/dev/null || true
+}
+
+make_target() {
+  [ "${BUILD_WITH_DEBUG}" = "yes" ] && PKG_DEBUG=1 || PKG_DEBUG=0
+  export PATH=$TOOLCHAIN/lib/gcc-linaro-aarch64-elf/bin/:$TOOLCHAIN/lib/gcc-linaro-arm-eabi/bin/:$PATH
+  DEBUG=${PKG_DEBUG} CROSS_COMPILE=aarch64-elf- ARCH=arm CFLAGS="" LDFLAGS="" make mrproper
+  DEBUG=${PKG_DEBUG} CROSS_COMPILE=aarch64-elf- ARCH=arm CFLAGS="" LDFLAGS="" make $PKG_UBOOT_CONFIG
+  DEBUG=${PKG_DEBUG} CROSS_COMPILE=aarch64-elf- ARCH=arm CFLAGS="" LDFLAGS="" make HOSTCC="$HOST_CC" HOSTSTRIP="true"
+}
+
+makeinstall_target() {
+    : # nothing
+}

--- a/projects/Amlogic/packages/u-boot-NanoPi_K2/patches/u-boot-0001-fix-toolchain-path.patch
+++ b/projects/Amlogic/packages/u-boot-NanoPi_K2/patches/u-boot-0001-fix-toolchain-path.patch
@@ -1,0 +1,13 @@
+diff --git a/arch/arm/cpu/armv8/gxb/firmware/scp_task/Makefile b/arch/arm/cpu/armv8/gxb/firmware/scp_task/Makefile
+index 6461bbe..9a63a9e 100644
+--- a/arch/arm/cpu/armv8/gxb/firmware/scp_task/Makefile
++++ b/arch/arm/cpu/armv8/gxb/firmware/scp_task/Makefile
+@@ -6,7 +6,7 @@ include $(buildtree)/include/autoconf.mk
+ include $(buildtree)/.config
+ 
+ # Select ARMv7-m bare-metal toolchain
+-CROSS_COMPILE=arm-linux-
++CROSS_COMPILE=arm-none-eabi-
+ ASM=$(CROSS_COMPILE)as
+ CC=$(CROSS_COMPILE)gcc
+ CPP=$(CROSS_COMPILE)cpp


### PR DESCRIPTION
This PR adds support for NanoPi K2.

Unfinished.. u-boot still needs patching to accept cfgload.