### PR TITLE
fix Wake-on-Lan by external RTL8211F for S912 devices

### DIFF
--- a/packages/linux/patches/rtl8221f_wol_S912_gpioz_15.patch
+++ b/packages/linux/patches/rtl8221f_wol_S912_gpioz_15.patch
@@ -1,0 +1,149 @@
+diff --git a/drivers/net/phy/phy_device.c b/drivers/net/phy/phy_device.c
+old mode 100644
+new mode 100755
+index 4bf046a..9cad0c4
+--- a/drivers/net/phy/phy_device.c
++++ b/drivers/net/phy/phy_device.c
+@@ -1406,6 +1406,8 @@ int genphy_resume(struct phy_device *phydev)
+ 
+ 	mutex_unlock(&phydev->lock);
+ 
++	phy_init_hw(phydev);
++
+ 	return 0;
+ }
+ EXPORT_SYMBOL(genphy_resume);
+diff --git a/drivers/net/phy/realtek.c b/drivers/net/phy/realtek.c
+old mode 100644
+new mode 100755
+index 6db788d..3462945
+--- a/drivers/net/phy/realtek.c
++++ b/drivers/net/phy/realtek.c
+@@ -35,6 +35,19 @@ MODULE_DESCRIPTION("Realtek PHY driver");
+ MODULE_AUTHOR("Johnson Leung");
+ MODULE_LICENSE("GPL");
+ 
++static u8 DEFMAC[] = {0, 0, 0, 0, 0, 0};
++
++unsigned char chartonum(char c)
++{
++	if (c >= '0' && c <= '9')
++		return c - '0';
++	if (c >= 'A' && c <= 'F')
++		return (c - 'A') + 10;
++	if (c >= 'a' && c <= 'f')
++		return (c - 'a') + 10;
++	return 0;
++}
++
+ static int rtl8211f_config_init(struct phy_device *phydev)
+ {
+ 	int val;
+@@ -72,6 +85,11 @@ static int rtl8211f_config_init(struct phy_device *phydev)
+ 	phy_write(phydev, RTL821x_LCR, 0XC171); /*led configuration*/
+ 	phy_write(phydev, RTL821x_EPAGSR, 0x0);
+ 
++	/* enable INTB/PMEB */
++	phy_write(phydev, RTL821x_EPAGSR, 0xd40);
++	phy_write(phydev, 22, 0x20);
++	phy_write(phydev, RTL821x_EPAGSR, 0);
++
+ 	/* rx reg 21 bit 3 tx reg 17 bit 8*/
+ 	/* phy_write(phydev, 0x1f, 0xd08);
+ 	 * val =  phy_read(phydev, 0x15);
+@@ -81,6 +99,86 @@ static int rtl8211f_config_init(struct phy_device *phydev)
+ 	return 0;
+ }
+ 
++static int rtl8211f_suspend(struct phy_device *phydev)
++{
++	int val;
++
++	if (phydev->drv->features & 0x8000)
++	{
++		int i = 0;
++
++		for (i = 0; i < 6; i++)
++		{
++			if (DEFMAC[i] != 0)
++				break;
++		}
++
++		if (i != 6)
++		{
++			pr_info("set mac for wol = %02x:%02x:%02x:%02x:%02x:%02x\n", DEFMAC[0], DEFMAC[1], DEFMAC[2], DEFMAC[3], DEFMAC[4], DEFMAC[5]);
++
++			phy_write(phydev, MII_BMCR, 0x1040);
++
++			phy_write(phydev, RTL821x_EPAGSR, 0xd8c);
++			val = (DEFMAC[1] << 8) | DEFMAC[0];
++			phy_write(phydev, 16, val);
++			val = (DEFMAC[3] << 8) | DEFMAC[2];
++			phy_write(phydev, 17, val);
++			val = (DEFMAC[5] << 8) | DEFMAC[4];
++			phy_write(phydev, 18, val);
++			phy_write(phydev, RTL821x_EPAGSR, 0);
++
++			phy_write(phydev, RTL821x_EPAGSR, 0xd8a);
++			phy_write(phydev, 17, 0x9fff);
++			phy_write(phydev, RTL821x_EPAGSR, 0);
++
++			phy_write(phydev, RTL821x_EPAGSR, 0xd8a);
++			phy_write(phydev, 16, 0x1000);
++			phy_write(phydev, RTL821x_EPAGSR, 0);
++
++			phy_write(phydev, RTL821x_EPAGSR, 0xd80);
++			phy_write(phydev, 16, 0x3000);
++			phy_write(phydev, 17, 0x0020);
++			phy_write(phydev, 18, 0x03c0);
++			phy_write(phydev, 19, 0x0000);
++			phy_write(phydev, 20, 0x0000);
++			phy_write(phydev, 21, 0x0000);
++			phy_write(phydev, 22, 0x0000);
++			phy_write(phydev, 23, 0x0000);
++			phy_write(phydev, RTL821x_EPAGSR, 0);
++
++			phy_write(phydev, RTL821x_EPAGSR, 0xd8a);
++			phy_write(phydev, 19, 0x1002);
++			phy_write(phydev, RTL821x_EPAGSR, 0);
++		}
++	}
++	else
++	{
++		val = phy_read(phydev, MII_BMCR);
++		phy_write(phydev, MII_BMCR, val | BMCR_PDOWN);
++	}
++
++	return 0;
++}
++
++static int __init mac_addr_uboot(char *line)
++{
++	unsigned char mac[6];
++	int i = 0;
++	for (i = 0; i < 6 && line[0] != '\0' && line[1] != '\0'; i++) {
++		mac[i] = chartonum(line[0]) << 4 | chartonum(line[1]);
++		line += 3;
++	}
++	memcpy(DEFMAC, mac, 6);
++	pr_debug("uboot setup mac-addr: %02x:%02x:%02x:%02x:%02x:%02x\n",
++		DEFMAC[0], DEFMAC[1], DEFMAC[2], DEFMAC[3], DEFMAC[4],
++		DEFMAC[5]);
++
++	return 1;
++}
++
++__setup("mac=", mac_addr_uboot);
++
+ static int rtl821x_ack_interrupt(struct phy_device *phydev)
+ {
+ 	int err;
+@@ -169,7 +267,7 @@ static struct phy_driver rtl8211f_driver = {
+ 	.config_init	= rtl8211f_config_init,
+ 	.config_aneg	= &genphy_config_aneg,
+ 	.read_status	= &genphy_read_status,
+-	.suspend	= genphy_suspend,
++	.suspend	= rtl8211f_suspend,
+ 	.resume		= genphy_resume,
+ 	.driver		= { .owner = THIS_MODULE,},
+ };


### PR DESCRIPTION
This patch will use the PMEB interrupt pin of the RTL8211F device to check
for a matching WOL packet. The PMEB pin have to be connected to GPIOZ_15.