### PR TITLE
scripts/build: don't fail on sed with non existent file

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -441,8 +441,8 @@ fi
 
 cd $ROOT
 
-for i in $(find $SYSROOT_PREFIX/usr/lib/ -name "*.la" 2>/dev/null); do
-  sed -e "s:\(['= ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" -i $i
+for i in $(find $SYSROOT_PREFIX/usr/lib/ -name "*.la" ! -path '*/usr/lib/pulse/*' 2>/dev/null); do
+  sed -e "s:\(['= ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" -i $i || :
 done
 
 PKG_DEEPHASH=$(calculate_stamp)


### PR DESCRIPTION
When multiple packages are build simultaneously .la files from first package can already be removed after find call with another and sed fails. Known package to do this is pulse that's why also skip searching it's folder.