### PR TITLE
Kodi upstream patches for Subs-video frame stutter & 4th refresh switching option

### DIFF
--- a/packages/mediacenter/kodi/patches/amlogic/kodi-up-999-extra-refresh-change-switch-PR15506.patch
+++ b/packages/mediacenter/kodi/patches/amlogic/kodi-up-999-extra-refresh-change-switch-PR15506.patch
@@ -1,0 +1,110 @@
+From ad711a866996d131eb8341814f7d1624d7f9dbbf Mon Sep 17 00:00:00 2001
+From: Memphiz <memphis@machzwo.de>
+Date: Tue, 12 Feb 2019 18:45:17 +0100
+Subject: [PATCH 1/2] [GraphicsContext] - add a setting to adjust
+ refreshrate/resolution only on playback start
+
+---
+ .../resource.language.en_gb/resources/strings.po  |  7 ++++++-
+ system/settings/settings.xml                      |  1 +
+ xbmc/windowing/GraphicContext.cpp                 | 15 +++++++++++----
+ xbmc/windowing/GraphicContext.h                   |  3 ++-
+ 4 files changed, 20 insertions(+), 6 deletions(-)
+
+diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
+index b7ea31b0daa4..803f3b5b5f51 100644
+--- a/addons/resource.language.en_gb/resources/strings.po
++++ b/addons/resource.language.en_gb/resources/strings.po
+@@ -17866,7 +17866,12 @@ msgctxt "#36049"
+ msgid "Remote button press release time (ms)"
+ msgstr ""
+ 
+-#empty strings from id 36050 to 36098
++#: system/settings.xml
++msgctxt "#36050"
++msgid "On start"
++msgstr ""
++
++#empty strings from id 36051 to 36098
+ 
+ #: system/settings/settings.xml
+ msgctxt "#36099"
+diff --git a/system/settings/settings.xml b/system/settings/settings.xml
+index 54f7e4c931fc..19cfe2db185c 100755
+--- a/system/settings/settings.xml
++++ b/system/settings/settings.xml
+@@ -55,6 +55,7 @@
+               <option label="351">0</option> <!-- ADJUST_REFRESHRATE_OFF -->
+               <option label="36035">1</option> <!-- ADJUST_REFRESHRATE_ALWAYS -->
+               <option label="36036">2</option> <!-- ADJUST_REFRESHRATE_ON_STARTSTOP -->
++              <option label="36050">3</option> <!-- ADJUST_REFRESHRATE_ON_START -->
+             </options>
+           </constraints>
+           <control type="list" format="string" />
+diff --git a/xbmc/windowing/GraphicContext.cpp b/xbmc/windowing/GraphicContext.cpp
+index e50d39267a62..efe37967bf88 100644
+--- a/xbmc/windowing/GraphicContext.cpp
++++ b/xbmc/windowing/GraphicContext.cpp
+@@ -333,13 +333,20 @@ void CGraphicContext::SetFullScreenVideo(bool bOnOff)
+           bTriggerUpdateRes = true;
+       }
+     }
+-
++    
++    bool allowResolutionChangeOnStop = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_ON_START;
++    RESOLUTION targetResolutionOnStop = RES_DESKTOP;
+     if (bTriggerUpdateRes)
+       g_application.GetAppPlayer().TriggerUpdateResolution();
+     else if (CDisplaySettings::GetInstance().GetCurrentResolution() > RES_DESKTOP)
+-      SetVideoResolution(CDisplaySettings::GetInstance().GetCurrentResolution(), false);
+-    else
+-      SetVideoResolution(RES_DESKTOP, false);
++    {
++      targetResolutionOnStop = CDisplaySettings::GetInstance().GetCurrentResolution();
++    }
++    
++    if (allowResolutionChangeOnStop)
++    {
++      SetVideoResolution(targetResolutionOnStop, false);
++    }
+   }
+   else
+     SetVideoResolution(RES_WINDOW, false);
+diff --git a/xbmc/windowing/GraphicContext.h b/xbmc/windowing/GraphicContext.h
+index f7c308e5dbf9..ce83aa7f8ef8 100644
+--- a/xbmc/windowing/GraphicContext.h
++++ b/xbmc/windowing/GraphicContext.h
+@@ -52,7 +52,8 @@ enum AdjustRefreshRate
+ {
+   ADJUST_REFRESHRATE_OFF = 0,
+   ADJUST_REFRESHRATE_ALWAYS,
+-  ADJUST_REFRESHRATE_ON_STARTSTOP
++  ADJUST_REFRESHRATE_ON_STARTSTOP,
++  ADJUST_REFRESHRATE_ON_START,
+ };
+ 
+ class CGraphicContext : public CCriticalSection
+
+From a86dca60ce0945e9739cf209404c9fdfce42b990 Mon Sep 17 00:00:00 2001
+From: Memphiz <memphis@machzwo.de>
+Date: Fri, 15 Feb 2019 23:08:30 +0100
+Subject: [PATCH 2/2] squashme
+
+---
+ xbmc/windowing/GraphicContext.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xbmc/windowing/GraphicContext.cpp b/xbmc/windowing/GraphicContext.cpp
+index efe37967bf88..1ced49671b04 100644
+--- a/xbmc/windowing/GraphicContext.cpp
++++ b/xbmc/windowing/GraphicContext.cpp
+@@ -343,7 +343,7 @@ void CGraphicContext::SetFullScreenVideo(bool bOnOff)
+       targetResolutionOnStop = CDisplaySettings::GetInstance().GetCurrentResolution();
+     }
+     
+-    if (allowResolutionChangeOnStop)
++    if (allowResolutionChangeOnStop && !bTriggerUpdateRes)
+     {
+       SetVideoResolution(targetResolutionOnStop, false);
+     }
+

--- a/packages/mediacenter/kodi/patches/amlogic/kodi-up-999-subs-render-stutter-fix-PR15518.patch
+++ b/packages/mediacenter/kodi/patches/amlogic/kodi-up-999-subs-render-stutter-fix-PR15518.patch
@@ -1,0 +1,265 @@
+From cc56b72b11bbbb7969a1d0aa10163fe9e4dd5557 Mon Sep 17 00:00:00 2001
+From: kszaq <kszaquitto@gmail.com>
+Date: Tue, 12 Feb 2019 22:28:16 +0100
+Subject: [PATCH 1/3] [GLES] Simplify GL_UNPACK_ROW_LENGTH check
+
+---
+ .../VideoRenderers/LinuxRendererGLES.cpp      | 33 +++++++++----------
+ .../VideoRenderers/LinuxRendererGLES.h        |  1 +
+ 2 files changed, 16 insertions(+), 18 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+index ec4df2690421..35fff5fa494a 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+@@ -120,6 +120,15 @@ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsig
+   // frame is loaded after every call to Configure().
+   m_bValidated = false;
+ 
++  // GLES < 3.0 doesn't support strided textures (unless GL_UNPACK_ROW_LENGTH_EXT is supported)
++  unsigned int major, minor;
++  m_renderSystem->GetRenderVersion(major, minor);
++
++  if (major >= 3 || m_renderSystem->IsExtSupported("GL_EXT_unpack_subimage"))
++  {
++    m_unpackRowLengthSupported = true;
++  }
++
+   // setup the background colour
+   m_clearColour = CServiceBroker::GetWinSystem()->UseLimitedColor() ? (16.0f / 0xff) : 0.0f;
+ 
+@@ -262,32 +271,20 @@ void CLinuxRendererGLES::LoadPlane(CYuvPlane& plane, int type,
+ 
+   glBindTexture(m_textureTarget, plane.id);
+ 
+-  // OpenGL ES does not support strided texture input.
+   GLint pixelStore = -1;
+-  unsigned int pixelStoreKey = -1;
++
++#ifndef GL_UNPACK_ROW_LENGTH
++#define GL_UNPACK_ROW_LENGTH 0x0CF2
++#endif
+ 
+   if (stride != static_cast<int>(width * bps))
+   {
+-#if HAS_GLES >= 3
+-    unsigned int verMajor, verMinor;
+-    m_renderSystem->GetRenderVersion(verMajor, verMinor);
+-
+-    if (verMajor >= 3)
++    if (m_unpackRowLengthSupported)
+     {
+       glGetIntegerv(GL_UNPACK_ROW_LENGTH, &pixelStore);
+       glPixelStorei(GL_UNPACK_ROW_LENGTH, stride);
+-      pixelStoreKey = GL_UNPACK_ROW_LENGTH;
+     }
+     else
+-#elif defined (GL_UNPACK_ROW_LENGTH_EXT)
+-    if (m_renderSystem->IsExtSupported("GL_EXT_unpack_subimage"))
+-    {
+-      glGetIntegerv(GL_UNPACK_ROW_LENGTH_EXT, &pixelStore);
+-      glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, stride);
+-      pixelStoreKey = GL_UNPACK_ROW_LENGTH_EXT;
+-    }
+-    else
+-#endif
+     {
+       unsigned char *src(static_cast<unsigned char*>(data)),
+                     *dst(m_planeBuffer);
+@@ -301,7 +298,7 @@ void CLinuxRendererGLES::LoadPlane(CYuvPlane& plane, int type,
+   glTexSubImage2D(m_textureTarget, 0, 0, 0, width, height, type, GL_UNSIGNED_BYTE, pixelData);
+ 
+   if (pixelStore >= 0)
+-    glPixelStorei(pixelStoreKey, pixelStore);
++    glPixelStorei(GL_UNPACK_ROW_LENGTH, pixelStore);
+ 
+   // check if we need to load any border pixels
+   if (height < plane.texheight)
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+index f0a310ff931d..9aa7271e42ba 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+@@ -202,6 +202,7 @@ class CLinuxRendererGLES : public CBaseRenderer
+   AVColorPrimaries m_srcPrimaries;
+   bool m_toneMap = false;
+   unsigned char* m_planeBuffer = nullptr;
++  bool m_unpackRowLengthSupported = false;
+ 
+   // clear colour for "black" bars
+   float m_clearColour{0.0f};
+
+From 3902c7d70c8b52e708edf2fc4122a614d2f6a104 Mon Sep 17 00:00:00 2001
+From: kszaq <kszaquitto@gmail.com>
+Date: Tue, 12 Feb 2019 22:29:50 +0100
+Subject: [PATCH 2/3] [GLES] OverlayRendererGL: add support for BGRA and
+ UNPACK_ROW_LENGTH extensions for GLES
+
+---
+ .../VideoRenderers/OverlayRendererGL.cpp      | 59 ++++++++++++++++---
+ 1 file changed, 52 insertions(+), 7 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+index fe2b632d9401..1ea749834215 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+@@ -50,7 +50,6 @@ static void LoadTexture(GLenum target
+   const GLvoid *pixelData = pixels;
+ 
+ #ifdef HAS_GLES
+-  /** OpenGL ES does not support BGR so use RGB and swap later **/
+   GLenum internalFormat = alpha ? GL_ALPHA : GL_RGBA;
+   GLenum externalFormat = alpha ? GL_ALPHA : GL_RGBA;
+ #else
+@@ -61,9 +60,50 @@ static void LoadTexture(GLenum target
+   int bytesPerPixel = glFormatElementByteCount(externalFormat);
+ 
+ #ifdef HAS_GLES
++  // Some (most?) hardware supports BGRA textures via an extension.
++  // If not, we convert to RGBA first to avoid having to swizzle in shaders.
++  // Explicitly define GL_BGRA_EXT here in the case that it's not defined by
++  // system headers, and trust the extension list instead.
++#ifndef GL_BGRA_EXT
++#define GL_BGRA_EXT 0x80E1
++#endif
++
++  bool bgraSupported = false;
++  CRenderSystemGLES* renderSystem = dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
+ 
+-  /** OpenGL ES does not support BGR **/
+   if (!alpha)
++  {
++    if (renderSystem->IsExtSupported("GL_EXT_texture_format_BGRA8888") ||
++        renderSystem->IsExtSupported("GL_IMG_texture_format_BGRA8888"))
++    {
++      bgraSupported = true;
++      internalFormat = externalFormat = GL_BGRA_EXT;
++    }
++    else if (renderSystem->IsExtSupported("GL_APPLE_texture_format_BGRA8888"))
++    {
++      // Apple's implementation does not conform to spec. Instead, they require
++      // differing format/internalformat, more like GL.
++      bgraSupported = true;
++      externalFormat = GL_BGRA_EXT;
++    }
++  }
++
++  // GLES < 3.0 doesn't support strided textures (unless GL_UNPACK_ROW_LENGTH_EXT is supported)
++#ifndef GL_UNPACK_ROW_LENGTH
++#define GL_UNPACK_ROW_LENGTH 0x0CF2
++#endif
++
++  bool unpackRowLengthSupported = false;
++
++  unsigned int major, minor;
++  renderSystem->GetRenderVersion(major, minor);
++
++  if (major >= 3 || renderSystem->IsExtSupported("GL_EXT_unpack_subimage"))
++  {
++    unpackRowLengthSupported = true;
++  }
++
++  if (!alpha && !bgraSupported)
+   {
+     int bytesPerLine = bytesPerPixel * width;
+ 
+@@ -89,7 +129,7 @@ static void LoadTexture(GLenum target
+     stride = width;
+   }
+   /** OpenGL ES does not support strided texture input. Make a copy without stride **/
+-  else if (stride != width)
++  else if ((stride != width) && !unpackRowLengthSupported)
+   {
+     int bytesPerLine = bytesPerPixel * width;
+ 
+@@ -107,9 +147,11 @@ static void LoadTexture(GLenum target
+     pixelData = pixelVector;
+     stride = width;
+   }
+-#else
+-  glPixelStorei(GL_UNPACK_ROW_LENGTH, stride / bytesPerPixel);
++  else if (stride != width)
+ #endif
++  {
++    glPixelStorei(GL_UNPACK_ROW_LENGTH, stride / bytesPerPixel);
++  }
+ 
+   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+ 
+@@ -134,9 +176,12 @@ static void LoadTexture(GLenum target
+                    , externalFormat, GL_UNSIGNED_BYTE
+                    , (const unsigned char*)pixelData + bytesPerPixel * (width-1));
+ 
+-#ifndef HAS_GLES
+-  glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
++#ifdef HAS_GLES
++  if ((stride != width) && unpackRowLengthSupported)
+ #endif
++  {
++    glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
++  }
+ 
+   free(pixelVector);
+ 
+
+From 9a7d54b8c45f7acc72cb00c76b43d9927bef53ac Mon Sep 17 00:00:00 2001
+From: kszaq <kszaquitto@gmail.com>
+Date: Thu, 14 Feb 2019 21:02:54 +0100
+Subject: [PATCH 3/3] [GLES] OverlayRendererGL: stride should match
+ bytesPerLine, not width
+
+We align stride to bytesPerLine, so we should compare it, not width.
+---
+ .../VideoRenderers/OverlayRendererGL.cpp           | 14 ++++++--------
+ 1 file changed, 6 insertions(+), 8 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+index 1ea749834215..7a34e05d1357 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+@@ -103,10 +103,10 @@ static void LoadTexture(GLenum target
+     unpackRowLengthSupported = true;
+   }
+ 
++  int bytesPerLine = bytesPerPixel * width;
++
+   if (!alpha && !bgraSupported)
+   {
+-    int bytesPerLine = bytesPerPixel * width;
+-
+     pixelVector = (char *)malloc(bytesPerLine * height);
+ 
+     const char *src = (const char*)pixels;
+@@ -129,10 +129,8 @@ static void LoadTexture(GLenum target
+     stride = width;
+   }
+   /** OpenGL ES does not support strided texture input. Make a copy without stride **/
+-  else if ((stride != width) && !unpackRowLengthSupported)
++  else if ((stride != bytesPerLine) && !unpackRowLengthSupported)
+   {
+-    int bytesPerLine = bytesPerPixel * width;
+-
+     pixelVector = (char *)malloc(bytesPerLine * height);
+ 
+     const char *src = (const char*)pixels;
+@@ -145,9 +143,9 @@ static void LoadTexture(GLenum target
+     }
+ 
+     pixelData = pixelVector;
+-    stride = width;
++    stride = bytesPerLine;
+   }
+-  else if (stride != width)
++  else if (stride != bytesPerLine)
+ #endif
+   {
+     glPixelStorei(GL_UNPACK_ROW_LENGTH, stride / bytesPerPixel);
+@@ -177,7 +175,7 @@ static void LoadTexture(GLenum target
+                    , (const unsigned char*)pixelData + bytesPerPixel * (width-1));
+ 
+ #ifdef HAS_GLES
+-  if ((stride != width) && unpackRowLengthSupported)
++  if ((stride != bytesPerLine) && unpackRowLengthSupported)
+ #endif
+   {
+     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+


### PR DESCRIPTION
Memphiz patch adds a 4th refresh switching setting "On Start" so Kodi refresh switches on video playback start only. Helps users with slow switching TV's and AVR's and un necessary refresh switching when watching same fps content. Great for watching Netflix TV series. 

Downside - the Kodi GUI will stay at that refresh rate. On my S912 testing it's hardly noticeable, even at 24p.

Kszaq patch - fixes the very first Overlay render -->> video frame upset that occurs when you first activate Subtitles. It's blocked in upstream Kodi at the moment due to a 6+ months old lrusak PR that I doubt will make it into Kodi Leia.

These can always be removed if PR's merged in upstream Kodi.