### PR TITLE
CE settings: add mute hdmi audio & Oclock GPU

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-ce-002-add-coreelec-settings.patch
+++ b/packages/mediacenter/kodi/patches/kodi-ce-002-add-coreelec-settings.patch
@@ -1,21 +1,21 @@
-From e0106e0db9c5ff9d1a2eb433c44771e97a97a42e Mon Sep 17 00:00:00 2001
-From: cdu13a <cdu13a@gmail.com>
-Date: Tue, 12 Feb 2019 12:45:29 -0500
-Subject: CoreELEC Settings
+From 3d911e744c84fc1e837da898d0fb70689081ed23 Mon Sep 17 00:00:00 2001
+From: wrxtasy <wrxtasy@amnet.net.au>
+Date: Wed, 20 Feb 2019 16:28:21 +0800
+Subject: [PATCH] CE settings: add mute HDMI audio & GPU Oclocking
 
 ---
- .../resources/strings.po                      | 67 ++++++++++++++++++-
- system/settings/settings.xml                  | 34 ++++++++++
- xbmc/settings/Settings.cpp                    |  5 ++
- xbmc/settings/Settings.h                      |  5 ++
- xbmc/windowing/amlogic/WinSystemAmlogic.cpp   | 34 ++++++++++
- 5 files changed, 144 insertions(+), 1 deletion(-)
+ .../resources/strings.po                      | 87 ++++++++++++++++++-
+ system/settings/settings.xml                  | 46 ++++++++++
+ xbmc/settings/Settings.cpp                    |  7 ++
+ xbmc/settings/Settings.h                      |  7 ++
+ xbmc/windowing/amlogic/WinSystemAmlogic.cpp   | 46 ++++++++++
+ 5 files changed, 192 insertions(+), 1 deletion(-)
 
 diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
-index b28cd82141..2177ef4c08 100644
+index b7ea31b..57efa69 100644
 --- a/addons/resource.language.en_gb/resources/strings.po
 +++ b/addons/resource.language.en_gb/resources/strings.po
-@@ -8325,7 +8325,72 @@ msgctxt "#14277"
+@@ -8325,7 +8325,92 @@ msgctxt "#14277"
  msgid "Allow remote control from applications on other systems"
  msgstr ""
  
@@ -85,15 +85,35 @@ index b28cd82141..2177ef4c08 100644
 +msgid "Enable this if you have problems with HEVC content after seeking."
 +msgstr ""
 +
-+#empty strings from id 14293 to 14300
++#: system/settings/settings.xml
++msgctxt "#14293"
++msgid "Mute HDMI audio output."
++msgstr ""
++
++#: system/settings/settings.xml
++msgctxt "#14294"
++msgid "Enable this for Optical audio only. Requires a reboot."
++msgstr ""
++
++#: system/settings/settings.xml
++msgctxt "#14295"
++msgid "Overclock the GPU"
++msgstr ""
++
++#: system/settings/settings.xml
++msgctxt "#14296"
++msgid "Enable this for a faster Kodi user interface ! Warning ! This will increase chipset temperatures. Requires a reboot."
++msgstr ""
++
++#empty strings from id 14297 to 14300
  
  #. pvr "channels" settings group label
  #: system/settings/settings.xml
 diff --git a/system/settings/settings.xml b/system/settings/settings.xml
-index f87ac4b6f4..61ab180361 100755
+index 54f7e4c..6bc8774 100755
 --- a/system/settings/settings.xml
 +++ b/system/settings/settings.xml
-@@ -2989,6 +2989,40 @@
+@@ -2994,6 +2994,52 @@
          </setting>
        </group>
      </category>
@@ -129,16 +149,28 @@ index f87ac4b6f4..61ab180361 100755
 +          <default>false</default>
 +          <control type="toggle" />
 +        </setting>
++       <setting id="coreelec.amlogic.mutehdmiaudio" type="boolean" label="14293" help="14294">
++          <requirement>HAVE_AMCODEC</requirement>
++          <level>3</level>
++          <default>false</default>
++          <control type="toggle" />
++        </setting>
++      <setting id="coreelec.amlogic.maxgpuclock" type="boolean" label="14295" help="14296">
++          <requirement>HAVE_AMCODEC</requirement>
++          <level>3</level>
++          <default>false</default>
++          <control type="toggle" />
++        </setting>
 +      </group>
 +    </category>
      <category id="cache" label="439" help="36399">
        <visible>false</visible>
        <group id="1">
 diff --git a/xbmc/settings/Settings.cpp b/xbmc/settings/Settings.cpp
-index b299b73fac..dbaacc4cf4 100644
+index 829e7b5..58f17c2 100644
 --- a/xbmc/settings/Settings.cpp
 +++ b/xbmc/settings/Settings.cpp
-@@ -392,6 +392,11 @@ const std::string CSettings::SETTING_EVENTLOG_SHOW = "eventlog.show";
+@@ -393,6 +393,13 @@ const std::string CSettings::SETTING_EVENTLOG_SHOW = "eventlog.show";
  const std::string CSettings::SETTING_MASTERLOCK_LOCKCODE = "masterlock.lockcode";
  const std::string CSettings::SETTING_MASTERLOCK_STARTUPLOCK = "masterlock.startuplock";
  const std::string CSettings::SETTING_MASTERLOCK_MAXRETRIES = "masterlock.maxretries";
@@ -147,14 +179,16 @@ index b299b73fac..dbaacc4cf4 100644
 +const std::string CSettings::SETTING_COREELEC_AMLOGIC_LIMIT8BIT = "coreelec.amlogic.limit8bit";
 +const std::string CSettings::SETTING_COREELEC_AMLOGIC_FORCE422 = "coreelec.amlogic.force422";
 +const std::string CSettings::SETTING_COREELEC_AMLOGIC_HEVCWORKAROUND = "coreelec.amlogic.hevcworkaround";
++const std::string CSettings::SETTING_COREELEC_AMLOGIC_MUTEHDMIAUDIO = "coreelec.amlogic.mutehdmiaudio";
++const std::string CSettings::SETTING_COREELEC_AMLOGIC_MAXGPUCLOCK = "coreelec.amlogic.maxgpuclock";
  const std::string CSettings::SETTING_CACHE_HARDDISK = "cache.harddisk";
  const std::string CSettings::SETTING_CACHEVIDEO_DVDROM = "cachevideo.dvdrom";
  const std::string CSettings::SETTING_CACHEVIDEO_LAN = "cachevideo.lan";
 diff --git a/xbmc/settings/Settings.h b/xbmc/settings/Settings.h
-index 95baba2a7e..fc4063b7ee 100644
+index d0743b3..6b99e6e 100644
 --- a/xbmc/settings/Settings.h
 +++ b/xbmc/settings/Settings.h
-@@ -352,6 +352,11 @@ public:
+@@ -353,6 +353,13 @@ public:
    static const std::string SETTING_MASTERLOCK_LOCKCODE;
    static const std::string SETTING_MASTERLOCK_STARTUPLOCK;
    static const std::string SETTING_MASTERLOCK_MAXRETRIES;
@@ -163,14 +197,16 @@ index 95baba2a7e..fc4063b7ee 100644
 +  static const std::string SETTING_COREELEC_AMLOGIC_LIMIT8BIT;
 +  static const std::string SETTING_COREELEC_AMLOGIC_FORCE422;
 +  static const std::string SETTING_COREELEC_AMLOGIC_HEVCWORKAROUND;
++  static const std::string SETTING_COREELEC_AMLOGIC_MUTEHDMIAUDIO;
++  static const std::string SETTING_COREELEC_AMLOGIC_MAXGPUCLOCK;
    static const std::string SETTING_CACHE_HARDDISK;
    static const std::string SETTING_CACHEVIDEO_DVDROM;
    static const std::string SETTING_CACHEVIDEO_LAN;
 diff --git a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
-index 0637f83fc0..888b2387f2 100644
+index 0637f83..ca4e2d9 100644
 --- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
 +++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
-@@ -82,6 +82,40 @@ CWinSystemAmlogic::~CWinSystemAmlogic()
+@@ -82,6 +82,52 @@ CWinSystemAmlogic::~CWinSystemAmlogic()
  
  bool CWinSystemAmlogic::InitWindowSystem()
  {
@@ -206,6 +242,18 @@ index 0637f83fc0..888b2387f2 100644
 +  {
 +     //attr.append("now");
 +     SysfsUtils::SetString("/sys/class/amhdmitx/amhdmitx0/attr", attr.c_str());
++  }
++
++  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_COREELEC_AMLOGIC_MUTEHDMIAUDIO))
++  {
++     CLog::Log(LOGDEBUG, "CWinSystemAmlogic::InitWindowSystem -- muting hdmi audio");
++     SysfsUtils::SetString("/sys/class/amhdmitx/amhdmitx0/config", "audio_off");
++  }
++
++  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_COREELEC_AMLOGIC_MAXGPUCLOCK))
++  {
++     CLog::Log(LOGDEBUG, "CWinSystemAmlogic::InitWindowSystem -- increasing GPU clock rate");
++     SysfsUtils::SetString("/sys/class/mpgpu/scale_mode", "2");
 +  }
 +
    m_nativeDisplay = EGL_DEFAULT_DISPLAY;


### PR DESCRIPTION
HDMI mute - beneficial for users with old AVR's that need SPDIF only audio
thx @samnazarko 

And Max out the GPU clock for various AML S9xx platforms.