### PR TITLE
opengl-meson-t82x: bump package to d3e7cfe

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -25,8 +25,8 @@ case "$LINUX" in
     PKG_BUILD_PERF="no"
     ;;
   amlogic-3.14)
-    PKG_VERSION="0b4adecbd7d7cebd937ed87576c675a43fc548d9"
-    PKG_SHA256="80bdf5eee3ac5e1aba128cf123bf449190db71460674d93d2f5c47feb6e6e224"
+    PKG_VERSION="73c86f34b32f1c97cf9e659099e4ded2beeb5324"
+    PKG_SHA256="20b9e0e13e82ae0a06f1f9325a997efe0aabe1b3dfc3d7543909a358dd04ba35"
     PKG_URL="https://github.com/CoreELEC/linux-amlogic/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_NAME="linux-$LINUX-$PKG_VERSION.tar.gz"
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET aml-dtbtools:host"

--- a/projects/Amlogic/packages/opengl-meson-t82x/package.mk
+++ b/projects/Amlogic/packages/opengl-meson-t82x/package.mk
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
+# Copyright (C) 2017-2019 Team LibreELEC (https://libreelec.tv)
+# Copyright (C) 2019-present Team CoreELEC (https://coreelec.org)
 
 PKG_NAME="opengl-meson-t82x"
-PKG_VERSION="915cb48"
-PKG_SHA256="9b5f65afa21250b67578c250da030a5829e69131ce91b2f167b01b1ed30be781"
+PKG_VERSION="d3e7cfed0c2b92640d874bb8c8c16d7ed832fdd4"
+PKG_SHA256="b4c9b2319da9b1d4aec4e401ee2bf7853303d75df4a192da7bd1e18353ec1334"
 PKG_LICENSE="nonfree"
-PKG_SITE="https://github.com/kszaq/opengl-meson-t82x"
-PKG_URL="https://github.com/kszaq/opengl-meson-t82x/archive/$PKG_VERSION.tar.gz"
+PKG_SITE="https://github.com/CoreELEC/opengl-meson-t82x"
+PKG_URL="https://github.com/CoreELEC/opengl-meson-t82x/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libhybris opengl-meson"
 PKG_SOURCE_DIR="$PKG_NAME-$PKG_VERSION*"
 PKG_LONGDESC="OpenGL ES pre-compiled libraries for Mali GPUs. The libraries were extracted from Khadas VIM2 Android firmware."


### PR DESCRIPTION
update to v3.2 Android Open GLES binaries