### PR TITLE
projects/Amlogic: copy aml_autoscript into khadas images

### DIFF
--- a/projects/Amlogic/bootloader/mkimage
+++ b/projects/Amlogic/bootloader/mkimage
@@ -5,7 +5,7 @@
 # Copyright (C) 2018-present Team CoreELEC (https://coreelec.org)
 
 # copy amlogic autoscript files to part1
-if [ "${SUBDEVICE}" == "Generic" ]; then
+if [ "${SUBDEVICE}" == "Generic" ] || [ "${SUBDEVICE}" == "KVIM" ] || [ "${SUBDEVICE}" == "KVIM2" ]; then
   for f in $RELEASE_DIR/3rdparty/bootloader/*autoscript; do
     [ -e "$f" ] && mcopy "$f" ::
   done


### PR DESCRIPTION
If a user has Android installed on the eMMC rather than our custom u-boot then aml_autoscript is needed on sdcard root to bootup CE.

This was a problem that I introduced in 9.0.1 after 7fb42f7b319bfbcfd6af46a7a66688210090d1f3.