### PR TITLE
u-boot-LePotato: bump package to c399719

### DIFF
--- a/projects/Amlogic/packages/u-boot-LePotato/package.mk
+++ b/projects/Amlogic/packages/u-boot-LePotato/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team CoreELEC (https://coreelec.org)
 
 PKG_NAME="u-boot-LePotato"
-PKG_VERSION="8da2299bdd0832ba3a7ca3543279b0d4d9c55b97"
-PKG_SHA256="f81b69423544c046eaebd8bfc83c1908643bbb561a447ecd9ae4bc6c4d087e03"
+PKG_VERSION="c399719ef82b69cce55160a39ac34be4c1c39ee5"
+PKG_SHA256="ab43ca1ba7b98ec4c15bac8f65a32d9d8c29228cf5ca07d0ad7d06b784b6d642"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.denx.de/wiki/U-Boot"


### PR DESCRIPTION
As discussed in Slack, it appears LibreComputer is not consistent in it's fabrication of LePotato boards and uses chips of varying specifications, reverted DDR clocks back to original values for maximum compatibility.