### PR TITLE
device-trees-amlogic: add missing dtbs

### DIFF
--- a/projects/Amlogic/packages/device-trees-amlogic/package.mk
+++ b/projects/Amlogic/packages/device-trees-amlogic/package.mk
@@ -19,7 +19,7 @@ make_target() {
 
   # Device trees already present in kernel tree we want to include
   EXTRA_TREES=( \
-                gxbb_p201 gxbb_p200_1G_wetek_hub gxbb_p200_2G_wetek_play_2 \
+                gxbb_p200 gxbb_p200_2G gxbb_p201 gxbb_p200_1G_wetek_hub gxbb_p200_2G_wetek_play_2 \
                 gxl_p212_1g gxl_p212_2g gxl_p281_1g gxl_p212_1g_lepotato gxl_p212_2g_lepotato \
                 gxm_q200_2g gxm_q201_1g gxm_q201_2g gxl_p231_1g_m8s_dvb \
 	      )


### PR DESCRIPTION
Sanity checking dtb at bootup in official releases has identified a few minor issues, this fixes an issue identified by @shantigilbert when he was using multidtb on one of his older devices, some dtbs are not present in /usr/share/bootloader/device_trees which causes the sanity check to fail and delay bootup.