### PR TITLE
dtb fixes

### DIFF
--- a/projects/Amlogic/bootloader/mkimage
+++ b/projects/Amlogic/bootloader/mkimage
@@ -16,7 +16,7 @@ for dtb in $RELEASE_DIR/3rdparty/bootloader/device_trees $RELEASE_DIR/3rdparty/b
   [ -e "$dtb" ] && mcopy -s "$dtb" ::
 done
 
-if [ -n ${SUBDEVICE} ]; then
+if [ "${SUBDEVICE}" != "Generic" ]; then
   if [ -f "$RELEASE_DIR/3rdparty/bootloader/${SUBDEVICE}_dtb.img" ]; then
     mcopy $RELEASE_DIR/3rdparty/bootloader/${SUBDEVICE}_dtb.img "::/dtb.img"
   fi

--- a/projects/Amlogic/packages/device-trees-amlogic/package.mk
+++ b/projects/Amlogic/packages/device-trees-amlogic/package.mk
@@ -20,8 +20,7 @@ make_target() {
   # Device trees already present in kernel tree we want to include
   EXTRA_TREES=( \
                 gxbb_p200 gxbb_p200_2G gxbb_p201 gxbb_p200_1G_wetek_hub gxbb_p200_2G_wetek_play_2 \
-                gxl_p212_1g gxl_p212_2g gxl_p281_1g gxl_p212_1g_lepotato gxl_p212_2g_lepotato \
-                gxm_q200_2g gxm_q201_1g gxm_q201_2g gxl_p231_1g_m8s_dvb \
+                gxl_p212_1g gxl_p212_2g gxl_p230_2g gxl_p281_1g gxm_q200_2g gxm_q201_1g gxm_q201_2g \
 	      )
 
   # Add trees to the list


### PR DESCRIPTION
gxl_p230_2g was missing from our images

also don't include dtb.img in our generic images, all users should be encouraged to copy the relevant dtb for their device rather than relying on multidtb