### PR TITLE
add additional requirement to the dtb sanity check

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -25,8 +25,8 @@ case "$LINUX" in
     PKG_BUILD_PERF="no"
     ;;
   amlogic-3.14)
-    PKG_VERSION="e22c12ba90288a4bc395111d98cf43a2b4dfcee2"
-    PKG_SHA256="ca133fb59f9fd18316947cefb8ac465ab33b0b861c051412afed3ded957ef2ac"
+    PKG_VERSION="04eb265384a01186891e564da1b9f0263a9f357e"
+    PKG_SHA256="e28242d8cdee63f8934e856cc196362067243493067686be0821e961ee57cae5"
     PKG_URL="https://github.com/CoreELEC/linux-amlogic/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_NAME="linux-$LINUX-$PKG_VERSION.tar.gz"
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET aml-dtbtools:host"

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -1056,7 +1056,8 @@
         DT_ID=$(cat /proc/device-tree/le-dt-id 2>/dev/null)
         DT_FILE=$(ls -1 /sysroot/usr/share/bootloader/device_trees/${DT_ID}.dtb 2>/dev/null | head -n 1)
 
-        if [ -n "${DT_ID}" ] &&
+        if [ -f "/proc/device-tree/coreelec" ] &&
+           [ -n "${DT_ID}" ] &&
            [ -f "${DT_FILE}" ]; then
            return 0
         fi


### PR DESCRIPTION
this PR adds an additional requirement to the dtb sanity check

as our stats have shown us there is >200 users using old/unsupported dtb's which are not updated when flashing an update tar

the sanity check at bootup will alert users to the fact that they are running an unsupported dtb and delay bootup, this is done in the hope that it will encourage users to update it

by adding the additional check the hope is that this will stop people using old kszaq 8.2 dtb's with coreelec or at the very least alert them that they are using an unsupported dtb