### PR TITLE
Revert "projects/Amlogic: enable SSH by default"

### DIFF
--- a/projects/Amlogic/linux/linux.aarch64.conf
+++ b/projects/Amlogic/linux/linux.aarch64.conf
@@ -366,7 +366,7 @@ CONFIG_FORCE_MAX_ZONEORDER=11
 #
 # Boot options
 #
-CONFIG_CMDLINE="console=tty0 systemd.show_status=auto ssh"
+CONFIG_CMDLINE="console=tty0 systemd.show_status=auto"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set


### PR DESCRIPTION
"ssh" in cmdline forces SSH server to be on, user should be able to disable it.

This reverts commit 45380490ccd6138a67a33cf9cb1238da7cf10456.