### PR TITLE
projects/Amlogic: remove mecool from default ir multi map

### DIFF
--- a/projects/Amlogic/options
+++ b/projects/Amlogic/options
@@ -164,7 +164,7 @@
     DRIVER_ADDONS="crazycat_aml dvb-latest"
 
   # add OOTB support for IR remote
-    IR_REMOTE_KEYMAPS="$IR_REMOTE_KEYMAPS odroid wetek_hub wetek_play_2 tanix mecool"
+    IR_REMOTE_KEYMAPS="$IR_REMOTE_KEYMAPS odroid wetek_hub wetek_play_2 tanix"
 
   # build with entware installer
     ENTWARE_SUPPORT="yes"


### PR DESCRIPTION
Introduced this in my Khadas PR.

The mecool remote map interferes with Philips TV's as KEY_DOWN on Philip's remote corresponds to KEY_POWER in the mecool map.