### PR TITLE
RTL8812AU: fix building package on 3.14

### DIFF
--- a/packages/linux-drivers/RTL8812AU/patches/RTL8812AU-01-fix-build-on-3-14.patch
+++ b/packages/linux-drivers/RTL8812AU/patches/RTL8812AU-01-fix-build-on-3-14.patch
@@ -1,0 +1,11 @@
+--- a/os_dep/linux/usb_intf.c
++++ b/os_dep/linux/usb_intf.c
+@@ -1604,7 +1604,7 @@
+ static void rtw_dev_remove(struct usb_interface *pusb_intf)
+ {
+ 	struct dvobj_priv *dvobj = usb_get_intfdata(pusb_intf);
+-	//struct pwrctrl_priv *pwrctl = dvobj_to_pwrctl(dvobj);
++	struct pwrctrl_priv *pwrctl = dvobj_to_pwrctl(dvobj);
+ 	_adapter *padapter = dvobj->if1;
+ 	//struct net_device *pnetdev = padapter->pnetdev;
+ 	//struct mlme_priv *pmlmepriv= &padapter->mlmepriv;


### PR DESCRIPTION
my bad I only checked that the updated package compiled against 4.9, thanks to @shantigilbert for pointing this out