### PR TITLE
kodi: add PR15941 to fix GLES HQ scalers

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-999.16-PR15941-fix-GLES-HQ-scalers.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.16-PR15941-fix-GLES-HQ-scalers.patch
@@ -1,0 +1,103 @@
+From 3322758e4e3872ffb10ad9bc25643b7a0f7721d9 Mon Sep 17 00:00:00 2001
+From: kszaq <kszaquitto@gmail.com>
+Date: Wed, 17 Apr 2019 22:21:15 +0200
+Subject: [PATCH] GL: fix HAS_FLOAT_TEXTURE usage
+
+In GLES shaders 'if defined(HAS_FLOAT_TEXTURE)' was always true
+as HAS_FLOAT_TEXTURE was always defined. Fix this by not defining
+HAS_FLOAT_TEXTURE when target does not support it and amend
+GL shaders to follow this behaviour.
+---
+ system/shaders/GL/1.2/gl_convolution-4x4.glsl                 | 2 +-
+ system/shaders/GL/1.2/gl_convolution-6x6.glsl                 | 2 +-
+ system/shaders/GL/1.5/gl_convolution-4x4.glsl                 | 2 +-
+ system/shaders/GL/1.5/gl_convolution-6x6.glsl                 | 2 +-
+ .../VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp       | 4 +---
+ .../VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp     | 3 +--
+ 6 files changed, 6 insertions(+), 9 deletions(-)
+
+diff --git a/system/shaders/GL/1.2/gl_convolution-4x4.glsl b/system/shaders/GL/1.2/gl_convolution-4x4.glsl
+index 0f580fea4119..32d955d8fb5e 100644
+--- a/system/shaders/GL/1.2/gl_convolution-4x4.glsl
++++ b/system/shaders/GL/1.2/gl_convolution-4x4.glsl
+@@ -35,7 +35,7 @@ uniform sampler1D kernelTex;
+ 
+ half4 weight(float pos)
+ {
+-#if (HAS_FLOAT_TEXTURE)
++#if defined(HAS_FLOAT_TEXTURE)
+   return texture1D(kernelTex, pos);
+ #else
+   return texture1D(kernelTex, pos) * 2.0 - 1.0;
+diff --git a/system/shaders/GL/1.2/gl_convolution-6x6.glsl b/system/shaders/GL/1.2/gl_convolution-6x6.glsl
+index 057d6dfed84a..01328a0c118b 100644
+--- a/system/shaders/GL/1.2/gl_convolution-6x6.glsl
++++ b/system/shaders/GL/1.2/gl_convolution-6x6.glsl
+@@ -35,7 +35,7 @@ uniform sampler1D kernelTex;
+ 
+ half3 weight(float pos)
+ {
+-#if (HAS_FLOAT_TEXTURE)
++#if defined(HAS_FLOAT_TEXTURE)
+   return texture1D(kernelTex, pos).rgb;
+ #else
+   return texture1D(kernelTex, pos).rgb * 2.0 - 1.0;
+diff --git a/system/shaders/GL/1.5/gl_convolution-4x4.glsl b/system/shaders/GL/1.5/gl_convolution-4x4.glsl
+index 84e92c69673f..144676ee2744 100644
+--- a/system/shaders/GL/1.5/gl_convolution-4x4.glsl
++++ b/system/shaders/GL/1.5/gl_convolution-4x4.glsl
+@@ -18,7 +18,7 @@ uniform sampler1D kernelTex;
+ 
+ half4 weight(float pos)
+ {
+-#if (HAS_FLOAT_TEXTURE)
++#if defined(HAS_FLOAT_TEXTURE)
+   return texture(kernelTex, pos);
+ #else
+   return texture(kernelTex, pos) * 2.0 - 1.0;
+diff --git a/system/shaders/GL/1.5/gl_convolution-6x6.glsl b/system/shaders/GL/1.5/gl_convolution-6x6.glsl
+index 950192d496a1..4af3744ae1f2 100644
+--- a/system/shaders/GL/1.5/gl_convolution-6x6.glsl
++++ b/system/shaders/GL/1.5/gl_convolution-6x6.glsl
+@@ -18,7 +18,7 @@ uniform sampler1D kernelTex;
+ 
+ half3 weight(float pos)
+ {
+-#if (HAS_FLOAT_TEXTURE)
++#if defined(HAS_FLOAT_TEXTURE)
+   return texture(kernelTex, pos).rgb;
+ #else
+   return texture(kernelTex, pos).rgb * 2.0 - 1.0;
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
+index f800997ffeb4..70aa7345376f 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
+@@ -84,9 +84,7 @@ ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method, bool str
+   }
+ 
+   if (m_floattex)
+-    defines = "#define HAS_FLOAT_TEXTURE 1\n";
+-  else
+-    defines = "#define HAS_FLOAT_TEXTURE 0\n";
++    defines = "#define HAS_FLOAT_TEXTURE\n";
+ 
+   //don't compile in stretch support when it's not needed
+   if (stretch)
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp
+index ce1885042fcb..a9aa0d6f8ec1 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp
+@@ -99,12 +99,11 @@ ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method)
+   if (m_floattex)
+   {
+     m_internalformat = GL_RGBA16F_EXT;
+-    defines = "#define HAS_FLOAT_TEXTURE 1\n";
++    defines = "#define HAS_FLOAT_TEXTURE\n";
+   }
+   else
+   {
+     m_internalformat = GL_RGBA;
+-    defines = "#define HAS_FLOAT_TEXTURE 0\n";
+   }
+ 
+   CLog::Log(LOGDEBUG, "GL: ConvolutionFilterShader: using %s defines:\n%s", shadername.c_str(), defines.c_str());


### PR DESCRIPTION
This PR adds https://github.com/xbmc/xbmc/pull/15941 to Kodi as the patch is not included in 18.2 final.

Without this patch all "HQ" SW scalers blur instead of sharpen (at least that's how it looks like) - screenshots available in Kodi PR.. I'm not sure if S905/S912 are powerful enough to use HQ scalers but Odroid-N2 should certainly benefit from this patch.

The patch can be dropped if/when merged to Kodi.