### PR TITLE
dvb-latest: Fix MyGica T230C v2 support

### DIFF
--- a/packages/linux-driver-addons/dvb/depends/media_tree/patches/media_tree-06-fix-si2168-cmd-timeout.patch
+++ b/packages/linux-driver-addons/dvb/depends/media_tree/patches/media_tree-06-fix-si2168-cmd-timeout.patch
@@ -1,0 +1,17 @@
+fix si2168 cmd timeout
+
+Some Si2168 demodulator commands may take 130-140 ms
+(DVB-T/T2 tuner MyGica T230C v2).
+Details: https://github.com/CoreELEC/CoreELEC/pull/208
+
+--- a/drivers/media/dvb-frontends/si2168.c
++++ b/drivers/media/dvb-frontends/si2168.c
+@@ -46,7 +46,7 @@ static int si2168_cmd_execute_unlocked(s
+ 
+ 	if (cmd->rlen) {
+ 		/* wait cmd execution terminate */
+-		#define TIMEOUT 70
++		#define TIMEOUT 200
+ 		timeout = jiffies + msecs_to_jiffies(TIMEOUT);
+ 		while (!time_after(jiffies, timeout)) {
+ 			ret = i2c_master_recv(client, cmd->args, cmd->rlen);

--- a/packages/linux-driver-addons/dvb/depends/media_tree/patches/media_tree-07-fix-si2157-init.patch
+++ b/packages/linux-driver-addons/dvb/depends/media_tree/patches/media_tree-07-fix-si2157-init.patch
@@ -1,0 +1,16 @@
+Fix compatibility with Si2141 tuner (e.g. MyGica T230C v2)
+which needs a next command for proper initialization.
+
+(Broken by media_tree-01-hauppauge.patch)
+
+--- a/drivers/media/tuners/si2157.c
++++ b/drivers/media/tuners/si2157.c
+@@ -120,7 +120,7 @@ static int si2157_init(struct dvb_fronte
+ 	}
+	cmd.rlen = 1;
+ 	ret = si2157_cmd_execute(client, &cmd);
+-	if (ret)
++	if (ret && (dev->chiptype != SI2157_CHIPTYPE_SI2141 || ret != -EAGAIN))
+ 		goto err;
+ 
+ 	/* Si2141 needs a second command before it answers the revision query */


### PR DESCRIPTION
Fix "DVB drivers from the latest kernel" support for USB DVB-T/T2 tuners based on Si2168 demodulator and Si2141 tuner (e.g. MyGica T230C v2, Evolveo Sigma T2, Tesla Proxy T2).

**Fixed**
1) Tvheadend HTSP Client: always No signal
2) Tvheadend continuous errors:

> Jun 07 21:55:59.150249 CoreELEC tvheadend[2603]: subscription: 0019: "127.0.0.1 [  | Kodi Media Center ]" subscribing on channel "Seznam.cz TV | T2", weight: 150, adapter: "Silicon Labs Si2168 #0 : DVB-T #0", network: "DVB-T Network", mux: "554MHz", provider: "CESKE RADIOKOMUNIKACE", service: "Seznam.cz TV | T2", profile="htsp", hostname="127.0.0.1", username="127.0.0.1", client="Kodi Media Center"
> Jun 07 21:56:04.936123 CoreELEC tvheadend[2603]: subscription: 0019: service instance is bad, reason: No input detected
> Jun 07 21:56:06.936284 CoreELEC tvheadend[2603]: subscription: 0019: No input source available for subscription "127.0.0.1 [  | Kodi Media Center ]" to channel "Seznam.cz TV | T2"
> Jun 07 21:56:08.936341 CoreELEC tvheadend[2603]: subscription: 0019: No input source available for subscription "127.0.0.1 [  | Kodi Media Center ]" to channel "Seznam.cz TV | T2"
> Jun 07 21:56:10.936421 CoreELEC tvheadend[2603]: subscription: 0019: No input source available for subscription "127.0.0.1 [  | Kodi Media Center ]" to channel "Seznam.cz TV | T2"
> Jun 07 21:56:12.936552 CoreELEC tvheadend[2603]: subscription: 0019: No input source available for subscription "127.0.0.1 [  | Kodi Media Center ]" to channel "Seznam.cz TV | T2"
> 

3) "No signal" issue when switching TV channels (same as https://github.com/CoreELEC/CoreELEC/pull/208).