### PR TITLE
Enable server feature for OpenVPN

### DIFF
--- a/packages/network/openvpn/package.mk
+++ b/packages/network/openvpn/package.mk
@@ -12,7 +12,6 @@ PKG_DEPENDS_TARGET="toolchain lzo openssl"
 PKG_LONGDESC="A full featured SSL VPN software solution that integrates OpenVPN server capabilities."
 
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_have_decl_TUNSETPERSIST=no \
-                           --disable-server \
                            --disable-plugins \
                            --enable-iproute2 IPROUTE=/sbin/ip \
                            --enable-management \


### PR DESCRIPTION
Enabling VPN functionality for HTPC boxes, which could be very usefull, when home router cant do that.

Tested with one client, works as expected:

```
Tue Jul 16 17:14:23 2019 OpenVPN 2.4.6 armv8a-libreelec-linux-gnueabi [SSL (OpenSSL)] [LZO] [LZ4] [EPOLL] [AEAD] built on Jul 16 2019
Tue Jul 16 17:14:23 2019 library versions: OpenSSL 1.0.2q  20 Nov 2018, LZO 2.10
Tue Jul 16 17:14:23 2019 Diffie-Hellman initialized with 2048 bit key
Tue Jul 16 17:14:23 2019 TUN/TAP device tun0 opened
Tue Jul 16 17:14:23 2019 TUN/TAP TX queue length set to 100
Tue Jul 16 17:14:23 2019 do_ifconfig, tt->did_ifconfig_ipv6_setup=0
Tue Jul 16 17:14:23 2019 /sbin/ip link set dev tun0 up mtu 1500
Tue Jul 16 17:14:23 2019 /sbin/ip addr add dev tun0 10.8.0.1/24 broadcast 10.8.0.255
Tue Jul 16 17:14:23 2019 Socket Buffers: R=[87380->87380] S=[16384->16384]
Tue Jul 16 17:14:23 2019 Listening for incoming TCP connection on [AF_INET][undef]:1194
Tue Jul 16 17:14:23 2019 TCPv4_SERVER link local (bound): [AF_INET][undef]:1194
Tue Jul 16 17:14:23 2019 TCPv4_SERVER link remote: [AF_UNSPEC]
Tue Jul 16 17:14:23 2019 MULTI: multi_init called, r=256 v=256
Tue Jul 16 17:14:23 2019 IFCONFIG POOL: base=10.8.0.2 size=252, ipv6=0
Tue Jul 16 17:14:23 2019 IFCONFIG POOL LIST
Tue Jul 16 17:14:23 2019 MULTI: TCP INIT maxclients=1024 maxevents=1028
Tue Jul 16 17:14:23 2019 Initialization Sequence Completed
```

Difference is just **80kB** (I think full VPN functionality definitivelly worth it):

```
~/openvpn # ls -la openvpn
-rwxr-xr-x    1 root     root        502756 Jul 16 16:04 openvpn
```

```
~/openvpn # ls -la /usr/sbin/openvpn
-rwxr-xr-x    1 root     root        424908 Feb 27 01:50 /usr/sbin/openvpn
```

Sucesfully tested autorun feature:
```
Jul 16 17:57:03 Obyvak systemd[1]: Starting OpenVPN Autorun Service...
Jul 16 17:57:03 Obyvak systemd[1]: Started OpenVPN Autorun Service.
```

with daemon service:

```
[Unit]
Description=OpenVPN Autorun Service
Requires=network-online.service
After=network-online.service

[Service]
Type=forking
ExecStart=/storage/openvpn/openvpn --daemon --config /storage/openvpn/Server.ovpn
Restart=always
RestartSec=15

[Install]
WantedBy=kodi.target
```

Forum thread: https://discourse.coreelec.org/t/openvpn-server/5981
