### PR TITLE
Add support for RTL8822BU (#1)

### DIFF
--- a/packages/linux-drivers/RTL8822BU/package.mk
+++ b/packages/linux-drivers/RTL8822BU/package.mk
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2018-present Team CoreELEC (https://coreelec.org)
+
+PKG_NAME="RTL8822BU"
+PKG_VERSION="dea3bb8e631191ded1839c53fb266d80ef7e8ad3"
+PKG_SHA256="34474838558a8502edc9bcd1091c8911ec128d50aeda2f83173b36c1a592250c"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/MeissnerEffect/rtl8822bu"
+PKG_URL="https://github.com/EntropicEffect/rtl8822bu/archive/$PKG_VERSION.tar.gz"
+PKG_SOURCE_DIR="rtl8822bu-$PKG_VERSION*"
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_NEED_UNPACK="$LINUX_DEPENDS"
+PKG_SECTION="driver"
+PKG_LONGDESC="Realtek RTL8822BU Linux driver"
+PKG_IS_KERNEL_PKG="yes"
+
+pre_make_target() {
+  unset LDFLAGS
+}
+
+make_target() {
+  make \
+       ARCH=$TARGET_KERNEL_ARCH \
+       KSRC=$(kernel_path) \
+       CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
+       CONFIG_POWER_SAVING=n
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/$(get_full_module_dir)/$PKG_NAME
+    cp *.ko $INSTALL/$(get_full_module_dir)/$PKG_NAME
+}

--- a/projects/Amlogic/options
+++ b/projects/Amlogic/options
@@ -124,7 +124,8 @@
     ADDITIONAL_DRIVERS="gpu-aml kvimfan-aml openvfd-driver
                         ap6xxx-aml mt7601u-aml mt7603u-aml mt7610u-aml qca9377-aml ssv6xxx-aml
                         RTL8188EU-aml RTL8189ES-aml RTL8189FS-aml RTL8192CU RTL8192DU RTL8192EU
-                        RTL8723BS-aml RTL8723DS-aml RTL8812AU RTL8814AU RTL8821CU RTL8822BU-aml"
+                        RTL8723BS-aml RTL8723DS-aml RTL8812AU RTL8814AU RTL8821CU RTL8822BU-aml
+			RTL8822BU"
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,


### PR DESCRIPTION
*ELEC newbie here, sorry for the dumb questions.

I took the github driver source from the [Archlinux AUR](https://aur.archlinux.org/packages/rtl8822bu-dkms-git/) (which I have used in the past on laptops) and packaged similar to how RTL8821CU was done in [a6d9454](https://github.com/CoreELEC/CoreELEC/commit/a6d9454c2172609e2b97568e4ca325c3bd1897be)
and in [0bf2780](https://github.com/CoreELEC/CoreELEC/commit/0bf27809aae57732156ec922ea2d36eeb791ff25).

Not sure if I should also put it in ` distributions/CoreELEC/options`
as done in [36a2798](https://github.com/CoreELEC/CoreELEC/commit/36a2798c7f10d0ee36049135177034bb14017018).

I have compiled an image for the Odroid N2 with the code as proposed and the driver works.
