### PR TITLE
Allow hdr10+ hevc streams to be output in hdr10 until downstream hdr10+ code is fixed

### DIFF
--- a/projects/Amlogic-ng/patches/linux/linux-01-temp_hdr10plus_workaround.patch
+++ b/projects/Amlogic-ng/patches/linux/linux-01-temp_hdr10plus_workaround.patch
@@ -1,0 +1,16 @@
+diff --git a/drivers/amlogic/media_modules/frame_provider/decoder/h265/vh265.c b/drivers/amlogic/media_modules/frame_provider/decoder/h265/vh265.c
+index 2dfacc430010..5fce0a7f5f97 100644
+--- a/drivers/amlogic/media_modules/frame_provider/decoder/h265/vh265.c
++++ b/drivers/amlogic/media_modules/frame_provider/decoder/h265/vh265.c
+@@ -1397,7 +1397,10 @@ struct tile_s {
+ 
+ #define SEI_MASTER_DISPLAY_COLOR_MASK 0x00000001
+ #define SEI_CONTENT_LIGHT_LEVEL_MASK  0x00000002
+-#define SEI_HDR10PLUS_MASK			  0x00000004
++//*FIXME* This should be restored to the proper value once downstream HDR10+ handling code is properly working
++//since for now this causes HDR10+ files to be be output in SDR for both HDR10+ and HDR10 capable setups
++//#define SEI_HDR10PLUS_MASK			  0x00000004
++#define SEI_HDR10PLUS_MASK			  0x00000000
+ 
+ #define VF_POOL_SIZE        32
+ 


### PR DESCRIPTION
Currently hdr10+ media is output in SDR, on both hdr10+ capable display chains as well as hdr10 capable ones. Since hdr10+ output is anyways broken, implement temporary hack so that hdr10+ hevc streams at least play in hdr10, by suppressing the relevant metadata from the decoder such that the problematic code downstream is not used.

(Tested on HDR10 capable display, but reported also for HDR10+ capable display at e.g. https://discourse.coreelec.org/t/coreelec-and-hdr10-hdr10-plus/4725/33)