### PR TITLE
avahi: remove disallow-other-stacks=yes

### DIFF
--- a/packages/network/avahi/package.mk
+++ b/packages/network/avahi/package.mk
@@ -57,8 +57,6 @@ pre_configure_target() {
 }
 
 post_makeinstall_target() {
-# for some reason avai can fail to start see: http://forums.gentoo.org/viewtopic-p-7322172.html#7322172
-  sed -e "s,^.*disallow-other-stacks=.*$,disallow-other-stacks=yes,g" -i $INSTALL/etc/avahi/avahi-daemon.conf
 # disable wide-area
   sed -e "s,^.*enable-wide-area=.*$,enable-wide-area=no,g" -i $INSTALL/etc/avahi/avahi-daemon.conf
 # publish-hinfo


### PR DESCRIPTION
This was originally added because SO_REUSEPORT was not available on older kernels

With this setting, avahi-daemon does not use either SO_REUSEADDR or SO_REUSEPORT, which means that other mDNS applications cannot access the multicast udp port 5353 at the same time. This includes mDNS clients which are simply trying to discover other services on the network. One such client exists in a PVR add-on I am writing for Kodi which currently fails in network discovery when run on CoreELEC.

See also grandcat/zeroconf#63