### PR TITLE
Fix image formats in Hyperion.NG

### DIFF
--- a/packages/addons/addon-depends/qt-everywhere/package.mk
+++ b/packages/addons/addon-depends/qt-everywhere/package.mk
@@ -27,8 +27,8 @@ PKG_CONFIGURE_OPTS_TARGET="-prefix /usr
                            -no-sql-mysql
                            -system-zlib
                            -no-mtdev
-                           -no-gif
-                           -no-libpng
+                           -qt-libjpeg
+                           -qt-libpng
                            -no-harfbuzz
                            -no-libproxy
                            -system-pcre

--- a/packages/addons/service/hyperion.ng/package.mk
+++ b/packages/addons/service/hyperion.ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team CoreELEC (https://coreelec.org)
 
 PKG_NAME="hyperion.ng"
-PKG_VERSION="fe728b15434d9f960eca899efb1dfebd7b9c319d"
-PKG_SHA256="44d792ea03b37116a19591066209ff224d5394e34d0016cdd3dcb0ee41d1bbdd"
+PKG_VERSION="1aba51e85c4c3f7cac438aa7bf6a845ef536b42e"
+PKG_SHA256="882dc3fa46a2edf1fd066649239dd27a8901077071a2418b5fd4d36eadf50fb0"
 PKG_REV="103"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/hyperion-project/hyperion.ng"

--- a/packages/addons/service/hyperion.ng/patches/Embed-QSQLITE-driver-and-qjpeg-plugin-at-Amlogic-platform.patch
+++ b/packages/addons/service/hyperion.ng/patches/Embed-QSQLITE-driver-and-qjpeg-plugin-at-Amlogic-platform.patch
@@ -1,7 +1,7 @@
 From 49f316aaec95e42cc9afb7305cafac2ca2994624 Mon Sep 17 00:00:00 2001
 From: Portisch <hugo.portisch@yahoo.de>
 Date: Sun, 17 Nov 2019 09:20:38 +0100
-Subject: [PATCH 2/3] Embed QSQLITE driver and qjpeg plugin at Amlogic platform
+Subject: [PATCH 1/1] Embed QSQLITE driver and image format plugins at Amlogic platform
 
 ---
  CMakeLists.txt                          | 7 +++++++
@@ -125,21 +125,19 @@ index 8667ac30..a3bbce01 100644
  endif()
  
 diff --git a/src/hyperiond/hyperiond.cpp b/src/hyperiond/hyperiond.cpp
-index 8fde0c5c..aa4f5d59 100644
+index 8fde0c5c..8f406765 100644
 --- a/src/hyperiond/hyperiond.cpp
 +++ b/src/hyperiond/hyperiond.cpp
-@@ -26,6 +26,11 @@
+@@ -26,6 +26,12 @@
  #include <HyperionConfig.h> // Required to determine the cmake options
  #include "hyperiond.h"
  
 +#ifdef ENABLE_AMLOGIC
 +#include <QtPlugin>
 +Q_IMPORT_PLUGIN(QJpegPlugin)
++Q_IMPORT_PLUGIN(QGifPlugin)
 +#endif
 +
  // Flatbuffer Server
  #include <flatbufserver/FlatBufferServer.h>
  
--- 
-2.17.1
-


### PR DESCRIPTION
GIF effects can now be played, and GIF, JPG and PNG files can be statically displayed on the LEDs (e.g. via the WebUI)

edit: Tested with [this images](https://www.w3.org/People/mimasa/test/imgformat/)