### PR TITLE
librespot: enable running on CoreELEC with CONFIG_CP15_BARRIER_EMULATION

### DIFF
--- a/packages/addons/service/librespot/source/resources/lib/ls_librespot.py
+++ b/packages/addons/service/librespot/source/resources/lib/ls_librespot.py
@@ -54,6 +54,7 @@ class Librespot(xbmc.Player):
         self.listitem.setPath(path=self.pulseaudio.url)
 
     def __enter__(self):
+        subprocess.Popen('[ -f /proc/sys/abi/cp15_barrier ] && echo 2 >/proc/sys/abi/cp15_barrier', shell=True)
         self.pulseaudio.load_modules()
         self.panics = 0
         self.librespot = None


### PR DESCRIPTION
the other option is to disable emulation in Linux kernel
(I don't understand what is this even for ...)

Edit: Rust needs kernel option and without it doesn't even run.