### PR TITLE
Fix compilation error for squashfs

### DIFF
--- a/packages/sysutils/squashfs/patches/squashfs-nocommon.patch
+++ b/packages/sysutils/squashfs/patches/squashfs-nocommon.patch
@@ -1,0 +1,11 @@
+--- a/squashfs-tools/mksquashfs.h
++++ b/squashfs-tools/mksquashfs.h
+@@ -143,7 +143,7 @@ struct append_file {
+ #endif
+
+ extern struct cache *reader_buffer, *fragment_buffer, *reserve_cache;
+-struct cache *bwriter_buffer, *fwriter_buffer;
++extern struct cache *bwriter_buffer, *fwriter_buffer;
+ extern struct queue *to_reader, *to_deflate, *to_writer, *from_writer,
+ 	*to_frag, *locked_fragment, *to_process_frag;
+ extern struct append_file **file_mapping;


### PR DESCRIPTION
Fixes following compilation error
read_fs.o:(.bss+0x0): multiple definition of `fwriter_buffer';
read_fs.o:(.bss+0x8): multiple definition of `bwriter_buffer'; mksquashfs.o:

It happen on new gcc which force -fno-common