### PR TITLE
Fix build against gcc 10

### DIFF
--- a/packages/compress/cpio/patches/fix_build_against_gcc_10.patch
+++ b/packages/compress/cpio/patches/fix_build_against_gcc_10.patch
@@ -1,0 +1,14 @@
+diff --git a/src/global.c b/src/global.c
+index 57e505a..5106271 100644
+--- a/src/global.c
++++ b/src/global.c
+@@ -184,9 +184,6 @@ unsigned int warn_option = 0;
+ /* Extract to standard output? */
+ bool to_stdout_option = false;
+ 
+-/* The name this program was run with.  */
+-char *program_name;
+-
+ /* A pointer to either lstat or stat, depending on whether
+    dereferencing of symlinks is done for input files.  */
+ int (*xstat) ();

--- a/packages/linux/patches/linux-010-fix-build-failure-against-gcc-10.patch
+++ b/packages/linux/patches/linux-010-fix-build-failure-against-gcc-10.patch
@@ -1,0 +1,26 @@
+diff --git a/scripts/dtc/dtc-lexer.l b/scripts/dtc/dtc-lexer.l
+index 3b41bfc..9b9c29e 100644
+--- a/scripts/dtc/dtc-lexer.l
++++ b/scripts/dtc/dtc-lexer.l
+@@ -39,7 +39,7 @@ LINECOMMENT	"//".*\n
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+ #define	YY_USER_ACTION \
+diff --git a/scripts/dtc/dtc-parser.tab.c_shipped b/scripts/dtc/dtc-parser.tab.c_shipped
+index ee1d8c3..699c3e5 100644
+--- a/scripts/dtc/dtc-parser.tab.c_shipped
++++ b/scripts/dtc/dtc-parser.tab.c_shipped
+@@ -73,7 +73,7 @@
+ #include "dtc.h"
+ #include "srcpos.h"
+
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+
+ extern int yylex(void);
+ extern void print_error(char const *fmt, ...);

--- a/packages/security/nss/patches/nss-07-fix_gcc_10_build.patch
+++ b/packages/security/nss/patches/nss-07-fix_gcc_10_build.patch
@@ -1,0 +1,35 @@
+diff --git a/lib/sqlite/sqlite3.c b/lib/sqlite/sqlite3.c
+index 3fed1b7..5804c06 100644
+--- a/lib/sqlite/sqlite3.c
++++ b/lib/sqlite/sqlite3.c
+@@ -109789,6 +109789,7 @@ SQLITE_PRIVATE Select *sqlite3SelectNew(
+   Expr *pOffset         /* OFFSET value.  NULL means no offset */
+ ){
+   Select *pNew;
++  Select *pReturn = 0;
+   Select standin;
+   sqlite3 *db = pParse->db;
+   pNew = sqlite3DbMallocZero(db, sizeof(*pNew) );
+@@ -109796,6 +109797,8 @@ SQLITE_PRIVATE Select *sqlite3SelectNew(
+     assert( db->mallocFailed );
+     pNew = &standin;
+     memset(pNew, 0, sizeof(*pNew));
++  } else {
++    pReturn = pNew;
+   }
+   if( pEList==0 ){
+     pEList = sqlite3ExprListAppend(pParse, 0, sqlite3Expr(db,TK_ASTERISK,0));
+@@ -109817,11 +109820,12 @@ SQLITE_PRIVATE Select *sqlite3SelectNew(
+   if( db->mallocFailed ) {
+     clearSelect(db, pNew, pNew!=&standin);
+     pNew = 0;
++    pReturn = 0;
+   }else{
+     assert( pNew->pSrc!=0 || pParse->nErr>0 );
+   }
+   assert( pNew!=&standin );
+-  return pNew;
++  return pReturn;
+ }
+ 
+ #if SELECTTRACE_ENABLED

--- a/packages/security/nss/patches/nss-07-fix_gcc_10_build.patch
+++ b/packages/security/nss/patches/nss-07-fix_gcc_10_build.patch
@@ -1,7 +1,7 @@
 diff --git a/lib/sqlite/sqlite3.c b/lib/sqlite/sqlite3.c
 index 3fed1b7..5804c06 100644
---- a/lib/sqlite/sqlite3.c
-+++ b/lib/sqlite/sqlite3.c
+--- a/nss/lib/sqlite/sqlite3.c
++++ b/nss/lib/sqlite/sqlite3.c
 @@ -109789,6 +109789,7 @@ SQLITE_PRIVATE Select *sqlite3SelectNew(
    Expr *pOffset         /* OFFSET value.  NULL means no offset */
  ){
@@ -31,5 +31,5 @@ index 3fed1b7..5804c06 100644
 -  return pNew;
 +  return pReturn;
  }
- 
+
  #if SELECTTRACE_ENABLED


### PR DESCRIPTION
Fixes compilation problem:

scripts/dtc/dtc-parser.tab.o:(.bss+0x50): multiple definition of `yylloc'; scripts/dtc/dtc-lexer.lex.o:(.bss+0x0)

(there will be more packages to fix)