### PR TITLE
Fix build of cpio against gcc 10

### DIFF
--- a/packages/compress/cpio/patches/fix_build_against_gcc_10.patch
+++ b/packages/compress/cpio/patches/fix_build_against_gcc_10.patch
@@ -1,0 +1,14 @@
+diff --git a/src/global.c b/src/global.c
+index 57e505a..5106271 100644
+--- a/src/global.c
++++ b/src/global.c
+@@ -184,9 +184,6 @@ unsigned int warn_option = 0;
+ /* Extract to standard output? */
+ bool to_stdout_option = false;
+ 
+-/* The name this program was run with.  */
+-char *program_name;
+-
+ /* A pointer to either lstat or stat, depending on whether
+    dereferencing of symlinks is done for input files.  */
+ int (*xstat) ();


### PR DESCRIPTION
again problem with multiple global variable.