### PR TITLE
Fix compilation errors on GCC 10 - take two

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/p7zip/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/p7zip/package.mk
@@ -22,5 +22,5 @@ make_target() {
 
 makeinstall_host() {
   mkdir -p $TOOLCHAIN/bin
-    cp bin/7za $TOOLCHAIN/bin
+  cp bin/7za $TOOLCHAIN/bin
 }

--- a/packages/addons/addon-depends/system-tools-depends/p7zip/patches/gcc10.patch
+++ b/packages/addons/addon-depends/system-tools-depends/p7zip/patches/gcc10.patch
@@ -1,0 +1,20 @@
+--- a/CPP/Windows/ErrorMsg.cpp	2020-05-28 00:35:02.729896917 +0200
++++ b/CPP/Windows/ErrorMsg.cpp	2020-05-28 00:40:01.676442629 +0200
+@@ -13,7 +13,7 @@
+   const char * txt = 0;
+   AString msg;
+ 
+-  switch(errorCode) {
++  switch(HRESULT(errorCode)) {
+     case ERROR_NO_MORE_FILES   : txt = "No more files"; break ;
+     case E_NOTIMPL             : txt = "E_NOTIMPL"; break ;
+     case E_NOINTERFACE         : txt = "E_NOINTERFACE"; break ;
+@@ -43,7 +43,7 @@
+   const char * txt = 0;
+   AString msg;
+ 
+-  switch(messageID) {
++  switch(HRESULT(messageID)) {
+     case ERROR_NO_MORE_FILES   : txt = "No more files"; break ;
+     case E_NOTIMPL             : txt = "E_NOTIMPL"; break ;
+     case E_NOINTERFACE         : txt = "E_NOINTERFACE"; break ;

--- a/packages/compress/cpio/patches/remove-superfluous-declaration-of-program_name.patch
+++ b/packages/compress/cpio/patches/remove-superfluous-declaration-of-program_name.patch
@@ -1,0 +1,15 @@
+Backport of https://git.savannah.gnu.org/cgit/cpio.git/commit/?id=641d3f489cf6238bb916368d4ba0d9325a235afb
+Author: Sergey Poznyakoff <gray@gnu.org>
+
+--- a/src/global.c
++++ b/src/global.c
+@@ -184,9 +184,6 @@ unsigned int warn_option = 0;
+ /* Extract to standard output? */
+ bool to_stdout_option = false;
+ 
+-/* The name this program was run with.  */
+-char *program_name;
+-
+ /* A pointer to either lstat or stat, depending on whether
+    dereferencing of symlinks is done for input files.  */
+ int (*xstat) ();

--- a/packages/devel/binutils/package.mk
+++ b/packages/devel/binutils/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="binutils"
-PKG_VERSION="2.32"
-PKG_SHA256="9b0d97b3d30df184d302bced12f976aa1e5fbf4b0be696cdebc6cca30411a46e"
+PKG_VERSION="2.34"
+PKG_SHA256="53537d334820be13eeb8acb326d01c7c81418772d626715c7ae927a7d401cab3"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/binutils/"
 PKG_URL="http://ftpmirror.gnu.org/binutils/$PKG_NAME-$PKG_VERSION.tar.gz"

--- a/packages/linux/patches/linux-010_remove_redundant_yylloc_declaration.patch
+++ b/packages/linux/patches/linux-010_remove_redundant_yylloc_declaration.patch
@@ -1,0 +1,24 @@
+Backport of https://git.kernel.org/pub/scm/utils/dtc/dtc.git/commit/?id=0e9225eb0dfec51def612b928d2f1836b092bc7e
+Author: Dirk Mueller <dmueller@suse.com>
+
+--- a/scripts/dtc/dtc-lexer.l	2020-05-28 01:16:56.137307054 +0200
++++ b/scripts/dtc/dtc-lexer.l	2020-05-28 01:17:12.254712180 +0200
+@@ -38,7 +38,6 @@
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+
+--- a/scripts/dtc/dtc-lexer.lex.c_shipped	2020-05-28 01:58:26.166061866 +0200
++++ b/scripts/dtc/dtc-lexer.lex.c_shipped	2020-05-28 01:58:55.899794407 +0200
+@@ -631,7 +631,6 @@
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */

--- a/packages/security/nss/patches/nss-07-fix-false-positive-sqlite3-gcc10-warning.patch
+++ b/packages/security/nss/patches/nss-07-fix-false-positive-sqlite3-gcc10-warning.patch
@@ -1,0 +1,32 @@
+Backport of https://www.sqlite.org/src/info/04e1edd8e5821a37
+Author: drh
+--- a/nss/lib/sqlite/sqlite3.c	2020-05-28 08:07:22.967712364 +0200
++++ b/nss/lib/sqlite/sqlite3.c	2020-05-28 08:12:56.112859500 +0200
+@@ -109788,10 +109788,10 @@
+   Expr *pLimit,         /* LIMIT value.  NULL means not used */
+   Expr *pOffset         /* OFFSET value.  NULL means no offset */
+ ){
+-  Select *pNew;
++  Select *pNew, *pAllocated;
+   Select standin;
+   sqlite3 *db = pParse->db;
+-  pNew = sqlite3DbMallocZero(db, sizeof(*pNew) );
++  pAllocated = pNew = sqlite3DbMallocZero(db, sizeof(*pNew) );
+   if( pNew==0 ){
+     assert( db->mallocFailed );
+     pNew = &standin;
+@@ -109816,12 +109816,11 @@
+   pNew->addrOpenEphm[1] = -1;
+   if( db->mallocFailed ) {
+     clearSelect(db, pNew, pNew!=&standin);
+-    pNew = 0;
++    pAllocated = 0;
+   }else{
+     assert( pNew->pSrc!=0 || pParse->nErr>0 );
+   }
+-  assert( pNew!=&standin );
+-  return pNew;
++  return pAllocated;
+ }
+ 
+ #if SELECTTRACE_ENABLED


### PR DESCRIPTION
There's already a pull request for that issue, I just picked relevant patches from upstream project and added a references to them in patches.

I also bumped binutils version and patched build of p7zip as that fixed building on Fedora 32.