### PR TITLE
udevil: reorder allowed_media_dirs config option

### DIFF
--- a/packages/sysutils/udevil/config/udevil.conf
+++ b/packages/sysutils/udevil/config/udevil.conf
@@ -101,7 +101,7 @@ allowed_groups = *
 # be permitted to unmount its associated loop device even though internal.
 # INCLUDING /MNT HERE IS NOT RECOMMENDED.  ALL ALLOWED MEDIA DIRECTORIES
 # SHOULD BE OWNED AND WRITABLE ONLY BY ROOT.
-allowed_media_dirs = /media, /var/media, /run/media/$USER
+allowed_media_dirs = /var/media, /media, /run/media/$USER
 
 
 # allowed_devices is the first criteria for what block devices users may mount


### PR DESCRIPTION
> allowed_media_dirs specifies the media directories in which user mount points
> may be located.  The first directory which exists and does not contain a
> wildcard will be used as the default media directory (normally /media or
> /run/media/$USER).

CoreELEC is using symbolic link for /media to /var/media and actual mounts
are made in /var/media (as seen in */proc/self/mountinfo*). To align first
directory mounting works correctly for partitions with same label names.

before
```
/dev/sdb1 on /var/media/COREELEC type vfat ......
/dev/sdc1 on /var/media/COREELEC type vfat ......
```
after
```
/dev/sdb1 on /var/media/COREELEC type vfat ......
/dev/sdc1 on /var/media/COREELEC-2 type vfat ......
```