### PR TITLE
Amlogic-ng: Support 4K GUI scaling on boot.

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -20,8 +20,8 @@ case $KODI_VENDOR in
     PKG_PATCH_DIRS="default coreelec"
     ;;
   amlogic-4.9)
-    PKG_VERSION="16836e72218c4203eabf4ba41a6b063cc1b1d7aa"
-    PKG_SHA256="fb6547f2cc1481324903863d04138dfb6a8440bf2888bc8c3537bb7a591f6302"
+    PKG_VERSION="d1faafb26053a79931a40fef0c3551a476c10a84"
+    PKG_SHA256="8fa644e587dfb39e7f18122f575028b9f6f2fdc0448aef1fe08c0fcf850d285b"
     PKG_URL="https://github.com/CoreELEC/xbmc/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_NAME="kodi-$PKG_VERSION.tar.gz"
     PKG_PATCH_DIRS="default coreelec"

--- a/packages/mediacenter/kodi/patches/coreelec/kodi-ce-100.01-rebrand.patch
+++ b/packages/mediacenter/kodi/patches/coreelec/kodi-ce-100.01-rebrand.patch
@@ -1,4 +1,4 @@
-From ddb5ab164e0601c721dcbfa5e085de7a09e5fe34 Mon Sep 17 00:00:00 2001
+From 57fd0282225f1a30a8e197f1b6408c473fafda67 Mon Sep 17 00:00:00 2001
 From: Arthur Liberman <arthur_liberman@hotmail.com>
 Date: Wed, 24 Jul 2019 02:27:29 +0300
 Subject: [PATCH] rebrand to coreelec, update skin, code remove images
@@ -64,7 +64,7 @@ index d65cc2943c..6e366f9e85 100644
  	<extension point="xbmc.addon.metadata">
  		<summary lang="af_ZA">Installeer Byvoegsels vanaf Kodi.tv</summary>
 diff --git a/addons/resource.language.en_gb/resources/strings.po b/addons/resource.language.en_gb/resources/strings.po
-index e3681c0d69..4b61226710 100644
+index 7d99bdff62..bc6e99765c 100644
 --- a/addons/resource.language.en_gb/resources/strings.po
 +++ b/addons/resource.language.en_gb/resources/strings.po
 @@ -615,7 +615,7 @@ msgstr ""
@@ -675,11 +675,11 @@ index 3c889717d1..3392248d2d 100644
  
 +For our most up-to date privacy policy please visit https://discourse.coreelec.org/privacy.
 diff --git a/system/peripherals.xml b/system/peripherals.xml
-index ff303e99ae..9969995ce2 100644
+index a0e9ce961c..ac3e041fef 100644
 --- a/system/peripherals.xml
 +++ b/system/peripherals.xml
-@@ -27,7 +27,7 @@
-     <setting key="power_avr_on_as" type="bool" label="36046" value="0" order="15" />
+@@ -28,7 +28,7 @@
+     <setting key="power_avr_on_as" type="bool" label="36046" value="0" order="16" />
  
      <setting key="tv_vendor" type="int" value="0" configurable="0" />
 -    <setting key="device_name" type="string" value="Kodi" configurable="0" />
@@ -688,7 +688,7 @@ index ff303e99ae..9969995ce2 100644
      <setting key="wake_devices_advanced" type="string" value="" configurable="0" />
      <setting key="standby_devices_advanced" type="string" value="" configurable="0" />
 diff --git a/version.txt b/version.txt
-index 7e1a162ba0..4a37368c40 100644
+index b2ee0fce43..514b58a8ba 100644
 --- a/version.txt
 +++ b/version.txt
 @@ -1,7 +1,7 @@
@@ -757,5 +757,5 @@ index 3bde0c9181..651879fb85 100644
  
    else if (m_section == CONTROL_BT_STORAGE)
 -- 
-2.25.1
+2.20.1
 

--- a/packages/mediacenter/kodi/patches/kodi-999.15-disable-using-tv-menu-language-by-default.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.15-disable-using-tv-menu-language-by-default.patch
@@ -1,12 +1,13 @@
-diff -Naur a/system/peripherals.xml b/system/peripherals.xml
---- a/system/peripherals.xml	2016-03-19 01:20:46.000000000 -0700
-+++ b/system/peripherals.xml	2016-04-13 11:07:51.605221474 -0700
-@@ -18,7 +18,7 @@
-     <setting key="cec_wake_screensaver" type="bool" value="1" label="36010" order="7" />
-     <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="8" lvalues="36028|13005|13011" />
-     <setting key="standby_tv_on_pc_standby" type="bool" value="1" label="36026" order="9" />
+diff --git a/system/peripherals.xml b/system/peripherals.xml
+index a0e9ce961c..2ac0819a7c 100644
+--- a/system/peripherals.xml
++++ b/system/peripherals.xml
+@@ -19,7 +19,7 @@
+     <setting key="cec_wake_screensaver" type="bool" value="1" label="36010" order="8" />
+     <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="9" lvalues="36028|13005|13011|13010|13009|36044|36045" />
+     <setting key="standby_tv_on_pc_standby" type="bool" value="1" label="36026" order="10" />
 -    <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="10" />
 +    <setting key="use_tv_menu_language" type="bool" value="0" label="36018" order="10" />
      <setting key="pause_playback_on_deactivate" type="bool" value="1" label="36033" configurable="0" />
-     <setting key="pause_or_stop_playback_on_deactivate" type="enum" value="231" label="36033" order="11" lvalues="231|36044|36045" />
-     <setting key="connected_device" type="enum" label="36019" value="36037" lvalues="36037|36038" order="12" />
+     <setting key="pause_or_stop_playback_on_deactivate" type="enum" value="231" label="36033" order="12" lvalues="231|36044|36045" />
+     <setting key="connected_device" type="enum" label="36019" value="36037" lvalues="36037|36038" order="13" />

--- a/projects/Amlogic-ng/bootloader/Odroid_C4_boot.ini
+++ b/projects/Amlogic-ng/bootloader/Odroid_C4_boot.ini
@@ -19,6 +19,7 @@ setenv heartbeat "1"
 setenv coreelec "quiet"
 setenv hdmimode "1080p60hz"
 setenv frac_rate_policy "0"
+setenv native_4k_gui "0"
 
 setenv rootopt "BOOT_IMAGE=kernel.img boot=UUID=@BOOT_UUID@ disk=UUID=@DISK_UUID@"
 setenv consoleopt "console=ttyS0,115200 console=tty0 no_console_suspend"
@@ -37,7 +38,7 @@ if test "${usbpower}" != ""; then setenv usbpower "enable_system_power=${usbpowe
 if test "${modeline}" != ""; then setenv cmode "modeline=${modeline}"; fi
 if test "${wol}" != ""; then setenv wol "enable_wol=${wol}"; fi
 if test "${voutmode}" != ""; then setenv voutmode "voutmode=${voutmode}"; fi
-setenv displayopt "hdmimode=${hdmimode} logo=osd0,loaded,0x3d800000 vout=${hdmimode},enable frac_rate_policy=${frac_rate_policy} ${voutmode}"
+setenv displayopt "hdmimode=${hdmimode} logo=osd0,loaded,0x3d800000 vout=${hdmimode},enable frac_rate_policy=${frac_rate_policy} native_4k_gui=${native_4k_gui} ${voutmode}"
 setenv initargs "${rootopt} ${consoleopt} max_freq_a53=${max_freq_a53} max_freq_a73=${max_freq_a73} ${wol} ${cec} ${irsetup} ${usbpower} ${gpiopower} ${usbopts} ${cmode}"
 setenv bootargs "${initargs} ${displayopt} ${coreelec}"
 

--- a/projects/Amlogic-ng/bootloader/Odroid_N2_boot.ini
+++ b/projects/Amlogic-ng/bootloader/Odroid_N2_boot.ini
@@ -19,6 +19,7 @@ setenv heartbeat "1"
 setenv coreelec "quiet"
 setenv hdmimode "1080p60hz"
 setenv frac_rate_policy "0"
+setenv native_4k_gui "0"
 
 setenv rootopt "BOOT_IMAGE=kernel.img boot=UUID=@BOOT_UUID@ disk=UUID=@DISK_UUID@"
 setenv consoleopt "console=ttyS0,115200 console=tty0 no_console_suspend"
@@ -37,7 +38,7 @@ if test "${usbpower}" != ""; then setenv usbpower "enable_system_power=${usbpowe
 if test "${modeline}" != ""; then setenv cmode "modeline=${modeline}"; fi
 if test "${wol}" != ""; then setenv wol "enable_wol=${wol}"; fi
 if test "${voutmode}" != ""; then setenv voutmode "voutmode=${voutmode}"; fi
-setenv displayopt "hdmimode=${hdmimode} logo=osd0,loaded,0x3d800000 vout=${hdmimode},enable frac_rate_policy=${frac_rate_policy} ${voutmode}"
+setenv displayopt "hdmimode=${hdmimode} logo=osd0,loaded,0x3d800000 vout=${hdmimode},enable frac_rate_policy=${frac_rate_policy} native_4k_gui=${native_4k_gui} ${voutmode}"
 setenv initargs "${rootopt} ${consoleopt} max_freq_a53=${max_freq_a53} max_freq_a73=${max_freq_a73} ${wol} ${cec} ${irsetup} ${usbpower} ${gpiopower} ${usbopts} ${cmode}"
 setenv bootargs "${initargs} ${displayopt} ${coreelec}"
 

--- a/projects/Amlogic-ng/bootloader/scripts/Generic_cfgload.src
+++ b/projects/Amlogic-ng/bootloader/scripts/Generic_cfgload.src
@@ -5,6 +5,7 @@ setenv remotewakeupmask "0xffffffff"
 setenv coreelec "quiet"
 setenv hdmimode "1080p60hz"
 setenv frac_rate_policy "0"
+setenv native_4k_gui "0"
 
 setenv rootopt "BOOT_IMAGE=kernel.img boot=LABEL=COREELEC disk=LABEL=STORAGE"
 
@@ -24,7 +25,7 @@ if test "${max_freq_a73}" != ""; then setenv max_freq_a73 "max_freq_a73=${max_fr
 if test "${modeline}" != ""; then setenv cmode "modeline=${modeline}"; fi
 if test "${wol}" != ""; then setenv wol "enable_wol=${wol}"; fi
 if test "${voutmode}" != ""; then setenv voutmode "voutmode=${voutmode}"; fi
-setenv displayopt "hdmimode=${hdmimode} logo=osd0,loaded,${fb_addr} frac_rate_policy=${frac_rate_policy} ${voutmode}"
+setenv displayopt "hdmimode=${hdmimode} logo=osd0,loaded,${fb_addr} frac_rate_policy=${frac_rate_policy} native_4k_gui=${native_4k_gui} ${voutmode}"
 setenv initargs "${rootopt} ${consoleopt} ${max_freq_a53} ${max_freq_a73} ${wol} ${cec} ${gpiopower} ${usbopts} ${cmode}"
 setenv bootargs "${bootargs} ${initargs} ${displayopt} ${coreelec}"
 

--- a/projects/Amlogic-ng/initramfs/platform_init
+++ b/projects/Amlogic-ng/initramfs/platform_init
@@ -25,6 +25,9 @@ for arg in $(cat /proc/cmdline); do
     frac_rate_policy=*)
       frac_rate_policy=${arg#*=}
       ;;
+    native_4k_gui=*)
+      native_4k_gui=${arg#*=}
+      ;;
   esac
 done
 
@@ -51,8 +54,14 @@ case $display_mode in
   480*)            X=720  Y=480  ;;
   576*)            X=720  Y=576  ;;
   720p*)           X=1280 Y=720  ;;
+  2160p*)          X=3840 Y=2160 ;;
   *)               X=1920 Y=1080 ;;
 esac
+
+if [ "$native_4k_gui" -eq "0" -a $X -gt 1920 ]; then
+  X=1920
+  Y=1080
+fi
 
 Y_VIRT=$(($Y * 2))
 
@@ -63,15 +72,15 @@ echo 0 > /sys/class/graphics/fb1/free_scale
 echo 1 > /sys/class/video/disable_video
 
 # Enable scaling for 4K output
-case $display_mode in
-  4k*|smpte*|2160*)
-    echo 0 0 1919 1079 > /sys/class/graphics/fb0/free_scale_axis
-    echo 0 0 3839 2159 > /sys/class/graphics/fb0/window_axis
-    echo 1920 > /sys/class/graphics/fb0/scale_width
-    echo 1080 > /sys/class/graphics/fb0/scale_height
-    echo 0x10001 > /sys/class/graphics/fb0/free_scale
-  ;;
-esac
+if [ "$native_4k_gui" == "0" ]; then
+  case $display_mode in
+    4k*|smpte*|2160*)
+      echo 0 0 1919 1079 > /sys/class/graphics/fb0/free_scale_axis
+      echo 0 0 3839 2159 > /sys/class/graphics/fb0/window_axis
+      echo 0x10001 > /sys/class/graphics/fb0/free_scale
+    ;;
+  esac
+fi
 
 # Enable framebuffer device
 echo 0 > /sys/class/graphics/fb0/blank


### PR DESCRIPTION
Corresponding CE PR for https://github.com/CoreELEC/xbmc/pull/1
I think a 2 linux reverts are also required. I will add the kodi bump and the linux bump to this PR when the other PR's are merged. 