### PR TITLE
bluez: Assign a DBus connection and BusName on startup

### DIFF
--- a/packages/network/bluez/system.d/bluetooth.service
+++ b/packages/network/bluez/system.d/bluetooth.service
@@ -6,6 +6,8 @@ Requires=bluetooth-defaults.service
 ConditionPathExists=/storage/.cache/services/bluez.conf
 
 [Service]
+Type=dbus
+BusName=org.bluez
 NotifyAccess=main
 EnvironmentFile=/storage/.cache/services/bluez.conf
 EnvironmentFile=-/run/libreelec/debug/bluez.conf
@@ -19,3 +21,4 @@ StartLimitInterval=0
 
 [Install]
 WantedBy=bluetooth.target
+Alias=dbus-org.bluez.service


### PR DESCRIPTION
Long time user, first time contributor.

See the history of the `system.d/bluetooth.service` file here: https://github.com/CoreELEC/CoreELEC/commits/coreelec-9.2/packages/network/bluez/system.d/bluetooth.service

Back in Feb 2014 the directives to launch `bluetoothd` service as a dbus-service were removed. See https://github.com/CoreELEC/CoreELEC/commit/53aa6b3d98468f61bd23a6f4ff393aa38076ee3d#diff-a5cae14da45a5e369c9806564f7a4ca6
Reason being: 
>*clean up dbus*
we dont want dbus-daemon to try-start bluez/obexd. we have
own service units. so this is pointless and just fails
with an error in journal

Then in Oct 2018 a change was made to use this service file to autostart `bluetoothd`. See 
https://github.com/CoreELEC/CoreELEC/commit/40622b2cea1dabef6c77438771e9af6e1e023f33#diff-a5cae14da45a5e369c9806564f7a4ca6
>default enable Bluetooth services

I guess the service units mentioned above were removed at some point, I've looked for them but cannot find them. This `system.d/bluetooth.service` appears to be the only service unit which can launch `bluetoothd` now.

I see now when `bluetoothd` starts it _does_ seem to register itself on the DBus (the `bluetoothd` daemon must have a way of doing that itself), it doesn't seem to assign itself the `org.bluez` bus name. That means it can send dbus messages to other services, but makes it hard for other services to send messages to `org.bluez` endpoints.

But more importantly, without this, it seems like the DBus policy rules in `/etc/dbus-1/system.d/bluetooth.conf` never get applied.

Can someone please double check my logic here? I'm not an expert with systemd nor dbus, so theres a chance I'm missing something totally obvious.

My end goal with this, is I am working to add a feature to PulseAudio to communicate to Bluez via DBus. It is currently not possible to do that because I need to add a DBus policy rule in `/etc/dbus-1/system.d/pulseaudio-system.conf` to allow sending to `org.bluez`, but need this patch in place before I can do that.