### PR TITLE
CoreELEC-settings: support factory-reset on eMMC dual boot installation

### DIFF
--- a/packages/mediacenter/CoreELEC-settings/scripts/factory-reset
+++ b/packages/mediacenter/CoreELEC-settings/scripts/factory-reset
@@ -13,6 +13,7 @@ hidecursor
 label=
 target=
 uuid=
+ceemmc=
 
 get_target() {
   for arg in $(cat /proc/cmdline); do
@@ -27,6 +28,10 @@ get_target() {
           UUID=*)
             uuid="${disk#*=}"
             target="$(blkid -U $uuid)"
+            ;;
+          FOLDER=*)
+            ceemmc="yes"
+            target="${disk#*=}"
             ;;
           /*)
             target="$disk"
@@ -52,6 +57,11 @@ if [ -f /storage/.cache/reset_oe ] ; then
     show_reset_msg
 
     StartProgress spinner "Performing hard reset... "
+    if [ "$ceemmc" = "yes" ] ; then
+      # storage is just subfolder on Android data partition
+      rm -rf /storage/* &>/dev/null
+      rm -rf /storage/.[!.]* &>/dev/null
+    else
       umount /storage
       mke2fs -t ext4 -m 0 $target &>/dev/null
       if [ ! -z $label ] ; then
@@ -60,7 +70,8 @@ if [ -f /storage/.cache/reset_oe ] ; then
       if [ ! -z $uuid ] ; then
         tune2fs -U $uuid $target &>/dev/null
       fi
-      StopProgress "done!"
+    fi
+    StopProgress "done!"
 
     echo
     StartProgress countdown "Rebooting in 5s... " 5 "NOW"


### PR DESCRIPTION
With dual boot installation on eMMC storage partition is just a subfolder on a Android data partition. That's why partition can't be formatted but only files and folders must be removed. The process can take longer time than formatting partition - depends on a number of files and folders.

Fixes https://discourse.coreelec.org/t/nightly-builds-new/8409/1578