### PR TITLE
Update RTL8821CU

### DIFF
--- a/projects/Amlogic-ce/packages/linux-drivers/RTL8821CU/package.mk
+++ b/projects/Amlogic-ce/packages/linux-drivers/RTL8821CU/package.mk
@@ -2,35 +2,22 @@
 # Copyright (C) 2018-present Team CoreELEC (https://coreelec.org)
 
 PKG_NAME="RTL8821CU"
+PKG_VERSION="51d00a7930293c4a1e5a49d8655335decb1df2c8"
+PKG_SHA256="f7f7d80e58af99e5374ae36cf45a4781f95e5df499eaefe0f878eb80dfcd7b2e"
 PKG_LICENSE="GPL"
-PKG_SITE="https://github.com/smp79/rtl8821CU"
+PKG_SITE="https://morrownr/8821cu/rtl8821CU"
+PKG_URL="https://github.com/morrownr/8821cu/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain linux"
 PKG_NEED_UNPACK="$LINUX_DEPENDS"
-PKG_SECTION="driver"
 PKG_LONGDESC="Realtek RTL8821CU Linux driver"
 PKG_IS_KERNEL_PKG="yes"
-
-case "$LINUX" in
-  amlogic-3.14)
-    PKG_VERSION="178fcbf4f1bf5b94580b5708016d0b2c2ded1720"
-    PKG_SHA256="29d3e053dd1fad37ee03de65e4ed2b25a4fb9aaf8bb6bd435da477753d03ad26"
-    PKG_URL="https://github.com/smp79/rtl8821CU/archive/$PKG_VERSION.tar.gz"
-    PKG_SOURCE_DIR="rtl8821CU-$PKG_VERSION*"
-    ;;
-  amlogic-4.9)
-    PKG_VERSION="f7910283478ac1b508ff163d30e4b374bf99f7cb"
-    PKG_SHA256="b2128cbc23ecf9b17bbbd9652a2453d73403276a56b11eb8a795d168156cd53e"
-    PKG_URL="https://github.com/smp79/rtl8821CU/archive/$PKG_VERSION.tar.gz"
-    PKG_SOURCE_DIR="rtl8821CU-$PKG_VERSION*"
-    ;;
-esac
 
 pre_make_target() {
   unset LDFLAGS
 }
 
 make_target() {
-  make \
+  make V=1 \
        ARCH=$TARGET_KERNEL_ARCH \
        KSRC=$(kernel_path) \
        CROSS_COMPILE=$TARGET_KERNEL_PREFIX \


### PR DESCRIPTION
Switched to a https://github.com/morrownr/8821cu repo and removed kernel 3.14 driver.
Runtime tested on LePotato with a 8821CU dongle.