### PR TITLE
inputstream.adaptive: bump to 2.4.7-Leia

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,13 +2,13 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
+PKG_VERSION="2.4.7-Leia"
+PKG_SHA256="07d4f89d64a88da8ec6682ad85da097e2ecb782c7ea622efd161c65a65d59e63"
 PKG_REV="1"
-PKG_VERSION="09ec268dc43044051305a0f8f3b0bb3e2e2283d4"
-PKG_SHA256="954b98319a9827e2f9ede772ee02a9ca22b403ef4becf120c291537949454eac"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
-PKG_SITE="https://github.com/peak3d/inputstream.adaptive"
-PKG_URL="https://github.com/peak3d/inputstream.adaptive/archive/$PKG_VERSION.tar.gz"
+PKG_SITE="https://github.com/xbmc/inputstream.adaptive"
+PKG_URL="https://github.com/xbmc/inputstream.adaptive/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain kodi-platform"
 PKG_SECTION=""
 PKG_SHORTDESC="inputstream.adaptive"


### PR DESCRIPTION
pretty big important Leia backport update that fixes a lot of add-ons
https://github.com/xbmc/inputstream.adaptive/pull/634