### PR TITLE
Amlogic-ce: add ondemand tuning script from LE/Amlogic

### DIFF
--- a/projects/Amlogic-ce/packages/systemd/scripts/cpufreq
+++ b/projects/Amlogic-ce/packages/systemd/scripts/cpufreq
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2015 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+SYS_CPUFREQ_GOV=$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)
+
+if [ "${SYS_CPUFREQ_GOV}" = "ondemand" ]; then
+  for io_is_busy in $(find /sys/devices/system/cpu -name io_is_busy); do
+    echo 1 > "${io_is_busy}"
+  done
+  for up_threshold in $(find /sys/devices/system/cpu -name up_threshold); do
+    echo 50 > "${up_threshold}"
+  done
+  for sampling_rate in $(find /sys/devices/system/cpu -name sampling_rate); do
+    echo 100000 > "${sampling_rate}"
+  done
+  for sampling_down_factor in $(find /sys/devices/system/cpu -name sampling_down_factor); do
+    echo 50 > "${sampling_down_factor}"
+  done
+else
+  echo "cpufreq: settings not found for current cpu governor." | systemd-cat -p info
+fi


### PR DESCRIPTION
The script adjusts ondemand tunables to make CPU scale more aggresively, resulting in smoother GUI and possibly some minor improvements when SW-decoding. Copied from upstream projects/Amlogic.