### PR TITLE
gobject-introspecion: fix building for host

### DIFF
--- a/packages/devel/gobject-introspection/package.mk
+++ b/packages/devel/gobject-introspection/package.mk
@@ -34,7 +34,6 @@ EOF
 }
 
 pre_configure_host() {
-  export LD_LIBRARY_PATH+=":$TOOLCHAIN/lib"
   CFLAGS+=" -fPIC"
 }
 


### PR DESCRIPTION
Without this patch, the build fails with
```
configure: error: C compiler cannot create executables
```
the cause is
```
/usr/bin/ld: error while loading shared libraries: libbfd-2.35.1.so: cannot open shared object file: No such file or directory
```

libbfd.so installs to `$TOOLCHAIN/$HOST_NAME/$TARGET_NAME`