### PR TITLE
Widevine: replace glibc version suffix solution to ENV variable

### DIFF
--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -13,8 +13,6 @@ PKG_DEPENDS_INIT="glibc"
 PKG_LONGDESC="The Glibc package contains the main C library."
 PKG_BUILD_FLAGS="-gold"
 
-[ "${TARGET_ARCH:0:3}" == "arm" ] && PKG_VERSION+="-arm64tls" || :
-
 case "${LINUX}" in
   amlogic-4.9)
     OPT_ENABLE_KERNEL=4.4.0

--- a/packages/devel/glibc/patches/arm/glibc-tls-libwidevinecdm.so-since-4.10.2252.0-has-TLS-with.patch
+++ b/packages/devel/glibc/patches/arm/glibc-tls-libwidevinecdm.so-since-4.10.2252.0-has-TLS-with.patch
@@ -1,16 +1,14 @@
-From 1f6f179986e941f8062019fe894996550bcb737a Mon Sep 17 00:00:00 2001
+From 61b3b546450ae0a70cb4a57fbb0e0fc47b331370 Mon Sep 17 00:00:00 2001
 From: Portisch <hugo.portisch@yahoo.de>
 Date: Sat, 5 Jun 2021 19:41:25 +0200
 Subject: [PATCH] tls: libwidevinecdm.so: since 4.10.2252.0 has TLS with
  64-byte alignment Change the max_align to 64U instead 16 to make it possible
  to use dlopen again. Tests by changing TLS_TCB_ALIGN directly showed up some
- random crashes. Reverence: https://lkml.org/lkml/2020/7/3/754 Modify
- 'VERSION' to show TLS 64 byte alignment compatibility.
+ random crashes. Reverence: https://lkml.org/lkml/2020/7/3/754
 
 ---
  elf/dl-tls.c | 5 +++++
- version.h    | 2 +-
- 2 files changed, 6 insertions(+), 1 deletion(-)
+ 1 file changed, 5 insertions(+)
 
 diff --git a/elf/dl-tls.c b/elf/dl-tls.c
 index 9fa62f5d..d8f2f740 100644
@@ -27,17 +25,7 @@ index 9fa62f5d..d8f2f740 100644
 +  max_align = MAX (max_align, 64U);
    size_t freetop = 0;
    size_t freebottom = 0;
-
-diff --git a/version.h b/version.h
-index 83cd1967..2cc5a35a 100644
---- a/version.h
-+++ b/version.h
-@@ -1,4 +1,4 @@
- /* This file just defines the current version number of libc.  */
-
- #define RELEASE "release"
--#define VERSION "2.32"
-+#define VERSION "2.32-arm64tls"
---
-2.30.0
+ 
+-- 
+2.31.1
 

--- a/projects/Amlogic-ce/packages/mediacenter/kodi/scripts/kodi-config
+++ b/projects/Amlogic-ce/packages/mediacenter/kodi/scripts/kodi-config
@@ -58,6 +58,11 @@ else #arm
   echo "MALLOC_MMAP_THRESHOLD_=8192" >> /run/libreelec/kodi.conf
 fi
 
+# required for inputstreamhelper to detect TLS 64-bytes support
+if [ -n "$(uname -m | grep arm)" ] || [ "$(uname -m)" == "aarch64" ]; then
+  echo "LIBC_WIDEVINE_PATCHLEVEL=1" >> /run/libreelec/kodi.conf
+fi
+
 if [ -f /storage/.config/kodi.conf ] ; then
   cat /storage/.config/kodi.conf >>/run/libreelec/kodi.conf
 fi


### PR DESCRIPTION
Replace the original glibc version suffix (*-arm64tls) to an environment variable.
This is latest solution in script.module.inputstreamhelper addon to detect that the glibc package already contains the TLS 64-byte alignment patch.

References:
https://github.com/emilsvennesson/script.module.inputstreamhelper/pull/450
https://github.com/emilsvennesson/script.module.inputstreamhelper/pull/457