### PR TITLE
linux: fix compilation against gcc 10.

### DIFF
--- a/projects/Amlogic-ce/packages/linux/patches/linux-010-fix-build-failure-against-gcc-10.patch
+++ b/projects/Amlogic-ce/packages/linux/patches/linux-010-fix-build-failure-against-gcc-10.patch
@@ -1,0 +1,24 @@
+Index: linux-85ae76432eacc6260121a1bea4d651e90efe1ebe/scripts/dtc/dtc-lexer.l
+===================================================================
+--- linux-85ae76432eacc6260121a1bea4d651e90efe1ebe.orig/scripts/dtc/dtc-lexer.l
++++ linux-85ae76432eacc6260121a1bea4d651e90efe1ebe/scripts/dtc/dtc-lexer.l
+@@ -38,7 +38,6 @@ LINECOMMENT	"//".*\n
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+Index: linux-85ae76432eacc6260121a1bea4d651e90efe1ebe/scripts/dtc/dtc-lexer.lex.c_shipped
+===================================================================
+--- linux-85ae76432eacc6260121a1bea4d651e90efe1ebe.orig/scripts/dtc/dtc-lexer.lex.c_shipped
++++ linux-85ae76432eacc6260121a1bea4d651e90efe1ebe/scripts/dtc/dtc-lexer.lex.c_shipped
+@@ -631,7 +631,6 @@ char *yytext;
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */


### PR DESCRIPTION
A multiple declaration error prevents building dtc which is part of the linux build tree.

This is well known problem already fixed in other branches ( #242  and #246 )

Let me know if you need more information or improvements on patch