### PR TITLE
ampart: add package

### DIFF
--- a/projects/Amlogic-ce/packages/tools/ampart/package.mk
+++ b/projects/Amlogic-ce/packages/tools/ampart/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (C) 2022-present 7Ji (pugokushin@gmail.com)
+
+PKG_NAME="ampart"
+PKG_VERSION="e6b363444e24ca32acda3a2ebe09e5edcdca41ae"
+PKG_SHA256="71faa1ef2a28d260b1535e7186a40862e4b5b757e7839f6e96a6c6e126997fa24"
+PKG_LICENSE="GPL3"
+PKG_SITE="https://github.com/7Ji/ampart"
+PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
+PKG_MAINTAINER="7Ji"
+PKG_LONGDESC="A simple, fast, yet reliable partition tool for Amlogic's proprietary emmc partition format."
+PKG_DEPENDS_TARGET="toolchain"
+PKG_TOOLCHAIN="make"
+
+makeinstall_target() {
+  mkdir -p $INSTALL/usr/sbin
+  cp -a $PKG_BUILD/ampart $INSTALL/usr/sbin
+} 


### PR DESCRIPTION
The package is a partition tool that can re-partition the emmc in one single command, and re-inits all of the partitions in one go. I think the current way ceemmc modifies the partition table and copies data  (loop mount) is kinda tricky and dangerous and reimplement the logic with a simple call to ampart would be way much easier.

ampart provides a ``--snapshot``/``--s`` argument that will output the current partition layout in the last two lines of output and return 0 for success, the offset/size in the first one will always be in byte, and the second one would be human-readable. These should be easy for scripts like ceemmc to parse
````
bootloader:0:4194304:0 reserved:37748736:67108864:0 cache:113246208:536870912:2 env:658505728:8388608:0 logo:675282944:33554432:1 recovery:717225984:33554432:1 rsv:759169024:8388608:1 tee:775946240:8388608:1 crypt:792723456:33554432:1 misc:834666496:33554432:1 boot:876609536:33554432:1 system:918552576:2147483648:1 data:3074424832:4743757824:4 
bootloader:0B:4M:0 reserved:36M:64M:0 cache:108M:512M:2 env:628M:8M:0 logo:644M:32M:1 recovery:684M:32M:1 rsv:724M:8M:1 tee:740M:8M:1 crypt:756M:32M:1 misc:796M:32M:1 boot:836M:32M:1 system:876M:2G:1 data:2932M:4524M:4
````
And ampart also provides a ``--clone``/``-c`` argument that will read partitions with the same format of outputs of ``--snapshot``/``--s`` with minimum check, on one hand a user can restore a messed up partition with a command like:
````
ampart /dev/mmcblk0 --clone bootloader:0B:4M:0 reserved:36M:64M:0 cache:108M:512M:2 env:628M:8M:0 logo:644M:32M:1 recovery:684M:32M:1 rsv:724M:8M:1 tee:740M:8M:1 crypt:756M:32M:1 misc:796M:32M:1 boot:836M:32M:1 system:876M:2G:1 data:2932M:4524M:4
````
on other hand scripts like ceemmc could parse the arg and repartition the emmc more easily. e.g. search for last part data and rewrite it to CE_STORAGE and CE_FLASH and calculate some size, and call ampart with a simple
````
ampart /dev/mmcblk0 --clone bootloader:0:4194304:0 reserved:37748736:67108864:0 cache:113246208:536870912:2 env:658505728:8388608:0 logo:675282944:33554432:1 recovery:717225984:33554432:1 rsv:759169024:8388608:1 tee:775946240:8388608:1 crypt:792723456:33554432:1 misc:834666496:33554432:1 boot:876609536:33554432:1 system:918552576:2147483648:1 data:3074424832:262930432:4 CE_STORAGE:3074424832:262930432:4 CE_FLASH:7281311744:536870912:4
````
or
````
ampart /dev/mmcblk0 --clone bootloader:0B:4M:0 reserved:36M:64M:0 cache:108M:512M:2 env:628M:8M:0 logo:644M:32M:1 recovery:684M:32M:1 rsv:724M:8M:1 tee:740M:8M:1 crypt:756M:32M:1 misc:796M:32M:1 boot:836M:32M:1 system:876M:2G:1 data:2932M:4012M:4 CE_STORAGE:2932M:4012M:4 CE_FLASH:6944M:512M:4
````
CE_STORAGE and CE_FLASH will then immediately be created under /dev and you can just create part/copy stuffs to them instead of tricky loop mounts. These are all done in less than 0.1 second.

The old loop mount method was extremely dangerous as I/O to the seemingly different partitions yet with overlapping physical underlying block device segments could happen (some Mr Dare-Anything user or some mistakes you made in the order of the installtaion logic) and it will easily destroy the data.

If you don't want users to use it, you can change the installation path and hide it from PATH
