### PR TITLE
add support to build on manjaro as well as arch and endeavouros

### DIFF
--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -174,7 +174,7 @@ case "${DISTRO}" in
         [XML::Parser]=XML-Parser
       )
       ;;
-    arch|endeavouros)
+    arch|endeavouros|manjaro)
       dep_map+=(
         [g++]=g++
         [mkfontscale]=xorg-mkfontscale
@@ -277,7 +277,7 @@ if [ "${#need_map[@]}" -gt 0 ]; then
       mageia)
         get_yes_no && sudo urpmi "${need_map[@]}"
         ;;
-      arch|endeavouros)
+      arch|endeavouros|manjaro)
         get_yes_no && sudo pacman -Sy "${need_map[@]}"
         ;;
       opensuse)


### PR DESCRIPTION
I would like to be able to build coreelec and downstream repos on manjaro, since endeavouros is already supported as a arch derivative, I am hopeful this simple MR will be accepted as well.