### PR TITLE
use 32bit entware installer on amlogic-ng-dv

### DIFF
--- a/projects/Amlogic-ce/devices/Amlogic-ng-dv/options
+++ b/projects/Amlogic-ce/devices/Amlogic-ng-dv/options
@@ -148,7 +148,7 @@
 
   # build with entware installer
     ENTWARE_SUPPORT="yes"
-    ENTWARE_ARCH="aarch64-k3.10"
+    ENTWARE_ARCH="armv7sf-k3.2"
 
   # CoreELEC Subdevices
     SUBDEVICES=""


### PR DESCRIPTION
amlogic-ng-dv build uses 64bit entware installer, which fails to install via the installentware script.

This PR changes entware installer relevant architecture.