### PR TITLE
Replace Amlogic VNC server package with an improved version

### DIFF
--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/changelog.txt
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/changelog.txt
@@ -1,3 +1,9 @@
+21.0.5
+- replace package source git repository
+- creating a source directory with the necessary files and their modifications
+- modify the service start script to be compatible with the new binary
+- add Hungarian translation of the add-on
+
 21.0.4
 - performance fixes
 

--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/package.mk
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/package.mk
@@ -2,13 +2,13 @@
 # Copyright (C) 2018-present Team CoreELEC (https://coreelec.org)
 
 PKG_NAME="aml-vnc"
-PKG_VERSION="c34903e68695110c6af5df6fb43797950a0f335b"
-PKG_SHA256="650b664c7fb402f37bb9f2001f3a26bc85ad04d9eb0f2c273c446514cc3c12f4"
-PKG_REV="4"
+PKG_VERSION="1.1.0"
+PKG_SHA256="50a0040b46019c2781f671401907be4b24fb9f5749a7e439c4111c0853a4fe58"
+PKG_REV="5"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="GPL"
-PKG_SITE="https://github.com/CoreELEC/aml-vnc"
-PKG_URL="https://github.com/CoreELEC/aml-vnc/archive/${PKG_VERSION}.tar.gz"
+PKG_SITE="https://github.com/dtechsrv/aml-vnc-server/"
+PKG_URL="https://github.com/dtechsrv/aml-vnc-server/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libvncserver"
 PKG_SECTION="service"
 PKG_SHORTDESC="Amlogic VNC server"
@@ -17,14 +17,6 @@ PKG_LONGDESC="Amlogic VNC server is a Virtual Network Computing (VNC) server for
 PKG_IS_ADDON="yes"
 PKG_ADDON_NAME="Amlogic VNC"
 PKG_ADDON_TYPE="xbmc.service"
-
-unpack() {
-  mkdir -p ${PKG_BUILD}/addon
-  tar --strip-components=3 -xf $SOURCES/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz \
-    -C ${PKG_BUILD}       ${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}/sources
-  tar --strip-components=3 -xf $SOURCES/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz \
-    -C ${PKG_BUILD}/addon ${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}/source
-}
 
 pre_configure_target() {
   export CFLAGS+=" -Wno-stringop-truncation"
@@ -35,11 +27,7 @@ makeinstall_target() {
 }
 
 addon() {
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
-    cp -P ${PKG_BUILD}/aml-vnc ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
-
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
-    cp $(get_build_dir libvncserver)/.${TARGET_NAME}/libvncserver.so.? ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
-
-  cp -PR ${PKG_BUILD}/addon/* ${ADDON_BUILD}/${PKG_ADDON_ID}
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib}
+  cp -P ${PKG_BUILD}/aml-vnc ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+  cp $(get_build_dir libvncserver)/.${TARGET_NAME}/libvncserver.so.? ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
 }

--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/bin/aml-vnc.start
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/bin/aml-vnc.start
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2016-2018 Team LibreELEC (https://libreelec.tv)
+# Copyright (C) 2018-present Team CoreELEC (https://coreelec.org)
+
+. /etc/profile
+
+oe_setup_addon service.aml-vnc
+
+if [ ${AML_VNC_PORT} != "5900" ] ; then
+  export VNC_PORT="${AML_VNC_PORT}"
+fi
+
+if [ ${AML_VNC_AUTH} == "true" ] ; then
+  export VNC_PASSWORD="${AML_VNC_PWD}"
+fi
+
+if [ ${AML_VNC_STAT} == "true" ] ; then
+  export VNC_SERVERNAME="${AML_VNC_NAME}"
+fi
+
+exec aml-vnc

--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/default.py
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/default.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2016-2018 Team LibreELEC (https://libreelec.tv)
+# Copyright (C) 2018-present Team CoreELEC (https://coreelec.org)

--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/power.d/aml-vnc.power
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/power.d/aml-vnc.power
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2016-2018 Team LibreELEC (https://libreelec.tv)
+# Copyright (C) 2018-present Team CoreELEC (https://coreelec.org)
+
+. /etc/profile
+
+SERVICE="service.aml-vnc.service"
+
+case "$1" in
+  pre)
+    if systemctl is-active "$SERVICE" &>/dev/null ; then
+      systemctl stop "$SERVICE"
+    fi
+    ;;
+  post)
+    if systemctl is-enabled "$SERVICE" &>/dev/null ; then
+      systemctl start "$SERVICE"
+    fi
+    ;;
+esac

--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/resources/language/resource.language.en_gb/strings.po
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/resources/language/resource.language.en_gb/strings.po
@@ -1,0 +1,33 @@
+# Kodi Media Center language file
+# Addon Name: Amlogic VNC Server
+# Addon id: service.aml-vnc
+# Addon Provider: Team CoreELEC
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgctxt "#30000"
+msgid "Server settings"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30002"
+msgid "Use authentication"
+msgstr ""
+
+msgctxt "#30003"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30004"
+msgid "Use static name instead of hostname"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Name to be displayed"
+msgstr ""

--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/resources/language/resource.language.hu_hu/strings.po
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/resources/language/resource.language.hu_hu/strings.po
@@ -1,0 +1,35 @@
+# Kodi Media Center language file
+# Addon Name: Amlogic VNC Server
+# Addon id: service.aml-vnc
+# Addon Provider: Team CoreELEC
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: hu_HU\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#30000"
+msgid "Server settings"
+msgstr "Szerver beállítások"
+
+msgctxt "#30001"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30002"
+msgid "Use authentication"
+msgstr "Hitelesítés használata"
+
+msgctxt "#30003"
+msgid "Password"
+msgstr "Jelszó"
+
+msgctxt "#30004"
+msgid "Use static name instead of hostname"
+msgstr "Statikus név használata a hosztnév helyett"
+
+msgctxt "#30005"
+msgid "Name to be displayed"
+msgstr "Megjelenített név"

--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/resources/settings.xml
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/resources/settings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<settings>
+    <category label="30000">
+		<setting type="lsep" />
+		<setting id="AML_VNC_PORT" type="number" label="30001" default="5900" />
+		<setting id="AML_VNC_AUTH" type="bool" label="30002" default="true" />
+		<setting id="AML_VNC_PWD" type="text" label="30003" default="coreelec" visible="eq(-1,true)" />
+		<setting id="AML_VNC_STAT" type="bool" label="30004" default="false" />
+		<setting id="AML_VNC_NAME" type="text" label="30005" default="CoreELEC" enable="eq(-1,true)" />
+    </category>
+</settings>

--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/settings-default.xml
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/settings-default.xml
@@ -1,0 +1,8 @@
+<settings>
+    <setting id="AML_VNC_PORT" value="5900" />
+    <setting id="AML_VNC_AUTH" value="true" />
+    <setting id="AML_VNC_PWD" value="coreelec" />
+    <setting id="AML_VNC_STAT" value="false" />
+    <setting id="AML_VNC_NAME" value="CoreELEC" />
+</settings>
+

--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/system.d/service.aml-vnc.service
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/system.d/service.aml-vnc.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=aml-vnc
+After=graphical.target
+
+[Service]
+ExecStart=/bin/sh -c "exec sh /storage/.kodi/addons/service.aml-vnc/bin/aml-vnc.start"
+TimeoutStopSec=1
+Restart=always
+RestartSec=2
+StartLimitInterval=0
+
+[Install]
+WantedBy=kodi.target


### PR DESCRIPTION
I modified the original work of @kszaq at several points and added many new things, such as improved image buffer comparison, mouse support, screen resolution change detection, etc.

The full changelog of the version included in the package is available here:
https://github.com/dtechsrv/aml-vnc-server/releases/tag/1.1.0

This package is prepared for the CoreELEC build system following its previous model, but many things had to be changed due to the modification of the aml-vnc binary.

_I only tested under `Amlogic-ng` because I don't have a device compatible with `Amlogic-ne`._