### PR TITLE
aml-vnc: bump package to 1.2.0

### DIFF
--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/changelog.txt
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/changelog.txt
@@ -1,3 +1,6 @@
+21.0.6
+- bump package to 1.2.0
+
 21.0.5
 - replace package source git repository
 - creating a source directory with the necessary files and their modifications

--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/package.mk
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team CoreELEC (https://coreelec.org)
 
 PKG_NAME="aml-vnc"
-PKG_VERSION="1.1.0"
-PKG_SHA256="50a0040b46019c2781f671401907be4b24fb9f5749a7e439c4111c0853a4fe58"
-PKG_REV="5"
+PKG_VERSION="1.2.0"
+PKG_SHA256="38009d0ea84868c7e077eb7594f2808bf5acdae3b7e691cb73fb800e9489d064"
+PKG_REV="6"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/dtechsrv/aml-vnc-server/"


### PR DESCRIPTION
List of changes since v1.1.0:
https://github.com/dtechsrv/aml-vnc-server/releases/tag/1.2.0