### PR TITLE
Don't disable ipv6 support for nfs mounts

### DIFF
--- a/packages/network/nfs-utils/package.mk
+++ b/packages/network/nfs-utils/package.mk
@@ -66,7 +66,6 @@ pre_configure_target() {
     --enable-tirpc \
     --enable-uuid \
     --disable-gss \
-    --disable-ipv6 \
     --without-tcp-wrappers"
 
   # use different paths /etc -> /storage/.config


### PR DESCRIPTION
The default image supports ipv6, so there isn't a good reason to hobble nfs mounts any more, if there ever was.