### PR TITLE
shell.service: close splash-image before starting shell

### DIFF
--- a/packages/sysutils/busybox/system.d/shell.service
+++ b/packages/sysutils/busybox/system.d/shell.service
@@ -5,6 +5,7 @@ After=multi-user.target
 [Service]
 Environment=TTY=1
 WorkingDirectory=/storage
+ExecStartPre=-/bin/killall -s SIGUSR1 splash-image
 ExecStartPre=/bin/sh -c 'echo -en "\033[?25h"'
 ExecStart=/bin/sh -c 'clear; lsb_release; . /etc/profile; exec /bin/sh'
 


### PR DESCRIPTION
CoreELEC's `splash-image` is closed by `kodi.bin` which is not started in `textmode`. Use `=-` to prevent failure in case splash screen is disabled by `nosplash`