### PR TITLE
aml-vnc: bump package to 1.2.1

### DIFF
--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/changelog.txt
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/changelog.txt
@@ -1,3 +1,6 @@
+22.0.1
+- bump package to 1.2.1
+
 22.0.0
 - add missing service alias
 - hide password on settings page

--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/package.mk
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team CoreELEC (https://coreelec.org)
 
 PKG_NAME="aml-vnc"
-PKG_VERSION="1.2.0"
-PKG_SHA256="38009d0ea84868c7e077eb7594f2808bf5acdae3b7e691cb73fb800e9489d064"
-PKG_REV="0"
+PKG_VERSION="1.2.1"
+PKG_SHA256="751231c4e8c295a71e750b05e5f371395add0cb1853e7f8fcd41ef1067abc4ae"
+PKG_REV="1"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/dtechsrv/aml-vnc-server/"
@@ -27,7 +27,9 @@ makeinstall_target() {
 }
 
 addon() {
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib}
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
   cp -P ${PKG_BUILD}/aml-vnc ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
   cp $(get_build_dir libvncserver)/.${TARGET_NAME}/libvncserver.so.? ${ADDON_BUILD}/${PKG_ADDON_ID}/lib
 }


### PR DESCRIPTION
List of changes since v1.2.0:
https://github.com/dtechsrv/aml-vnc-server/releases/tag/1.2.1