### PR TITLE
[S905X4] Fix HDMI resume black screen & mariadb boot hang

### DIFF
--- a/packages/databases/mariadb-connector-c/package.mk
+++ b/packages/databases/mariadb-connector-c/package.mk
@@ -25,14 +25,17 @@ post_makeinstall_target() {
   PLUGINP=${INSTALL}/usr/lib/mariadb/plugin
   mkdir -p ${INSTALL}/.tmp
   mv ${PLUGINP}/{caching_sha2_password,client_ed25519,sha256_password}.so ${INSTALL}/.tmp
+  
+  # keep shared library
+  LIBP=${INSTALL}/usr/lib/mariadb
+  mv ${LIBP}/libmariadb.so* ${INSTALL}/.tmp
 
   # drop all unneeded
   rm -rf ${INSTALL}/usr
 
   mkdir -p ${PLUGINP}
-  mv ${INSTALL}/.tmp/* ${PLUGINP}/
+  mv ${INSTALL}/.tmp/*.so ${PLUGINP}/
+  # Move lib to /usr/lib for Kodi compatibility
+  mv ${INSTALL}/.tmp/libmariadb.so* ${INSTALL}/usr/lib/
   rmdir ${INSTALL}/.tmp
-
-  # remove shared library
-  rm -f ${SYSROOT_PREFIX}/usr/lib/mariadb/libmariadb.so*
 }

--- a/projects/Amlogic-ce/filesystem/usr/lib/systemd/system-sleep/hdmi-resume.sh
+++ b/projects/Amlogic-ce/filesystem/usr/lib/systemd/system-sleep/hdmi-resume.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Force HDMI HPD on resume to fix black screen on S905X4
+case "$1" in
+  post)
+    if [ -f /sys/class/amhdmitx/amhdmitx0/hpd_state ]; then
+        echo "Force HDMI HPD on resume..."
+        echo 1 > /sys/class/amhdmitx/amhdmitx0/hpd_state
+    fi
+    ;;
+esac


### PR DESCRIPTION
### Problem
- S905X4 devices wake to a black screen due to HDMI handshake failure.
- Kodi crashes on boot due to missing `libmariadb.so.3`.

### Solution
- Added `system-sleep` hook to force HDMI HPD toggle on resume.
- Fixed `mariadb-connector-c` package to install library to correct path.