### PR TITLE
Amlogic-ce: S905X4 HDMI resume/HDR10+ fixes + mariadb-connector-c fix

### DIFF
--- a/projects/Amlogic-ce/filesystem/usr/lib/systemd/system-sleep/hdmi-resume.sh
+++ b/projects/Amlogic-ce/filesystem/usr/lib/systemd/system-sleep/hdmi-resume.sh
@@ -5,6 +5,22 @@ case "$1" in
     if [ -f /sys/class/amhdmitx/amhdmitx0/hpd_state ]; then
         echo "Force HDMI HPD on resume..."
         echo 1 > /sys/class/amhdmitx/amhdmitx0/hpd_state
+        
+        # Wait a moment for handshake to potentially settle (optional but recommended for caps reading, though we are setting policy regardless)
+        sleep 1
+
+        # HDR10+ Optimization
+        # Ensure HDR10+ processing is enabled
+        if [ -f /sys/class/amvecm/enable_hdr10plus ]; then
+            echo "Enabling HDR10+ support..."
+            echo 1 > /sys/class/amvecm/enable_hdr10plus
+        fi
+
+        # Set Dolby Vision HDR10 Policy to 1 (Passthrough/Dynamic Metadata)
+        if [ -f /sys/module/aml_media/parameters/dolby_vision_hdr10_policy ]; then
+            echo "Setting HDR10+ Policy to 1..."
+            echo 1 > /sys/module/aml_media/parameters/dolby_vision_hdr10_policy
+        fi
     fi
     ;;
 esac

--- a/projects/Amlogic-ce/filesystem/usr/lib/systemd/system-sleep/hdmi-resume.sh
+++ b/projects/Amlogic-ce/filesystem/usr/lib/systemd/system-sleep/hdmi-resume.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Force HDMI HPD on resume to fix black screen on S905X4
+case "$1" in
+  post)
+    if [ -f /sys/class/amhdmitx/amhdmitx0/hpd_state ]; then
+        echo "Force HDMI HPD on resume..."
+        echo 1 > /sys/class/amhdmitx/amhdmitx0/hpd_state
+    fi
+    ;;
+esac


### PR DESCRIPTION
### Description
This PR addresses critical resume and playback issues on S905X4 devices (verified on Homatics Box R 4K Plus)

### Changes
**Amlogic-ce (S905X4)**:
   - Added `system-sleep` hook to force HDMI HPD toggle on resume, fixing black screen wakeup issues.
   - Enforce `dolby_vision_hdr10_policy=1` (Dynamic Metadata Passthrough) on resume. This prevents the VS10 engine from falling back to static HDR10 conversion, ensuring proper HDR10+ playback.



### Verification
- **Device**: Homatics Box R 4K Plus (S905X4)
- **Resume**: Verified display wakes up immediately from suspend (no black screen).
- **HDR10+**: Verified TV reports "HDR10+" signal and sysfs policy confirms enabled state (`1`) after resume.