### PR TITLE
Add missing version tag to advancedsettings.xml

### DIFF
--- a/projects/Amlogic-ce/packages/mediacenter/kodi/config/advancedsettings.xml
+++ b/projects/Amlogic-ce/packages/mediacenter/kodi/config/advancedsettings.xml
@@ -1,4 +1,4 @@
-<advancedsettings>
+<advancedsettings version="1.0">
   <cputempcommand>/usr/bin/cputemp</cputempcommand>
   <gputempcommand>/usr/bin/gputemp</gputempcommand>
 


### PR DESCRIPTION
...to silence this persistent log warning:

```
2026-02-03 17:59:17.914 T:3990  warning <CSettingsManager>: missing version attribute
```