### PR TITLE
aml-vnc: bump package to 1.4.0_beta11

### DIFF
--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/changelog.txt
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/changelog.txt
@@ -1,5 +1,5 @@
 22.0.0
-- bump package to 1.4.0_beta10
+- bump package to 1.4.0_beta11
 - change addon icon
 - add new config options
 

--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/package.mk
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team CoreELEC (https://coreelec.org)
 
 PKG_NAME="aml-vnc"
-PKG_VERSION="1.4.0_beta10"
-PKG_SHA256="711b95b4926a92f57ab67909b2db4fe1388f51601935ce88dd789409e8ae1b83"
-PKG_REV="0~beta-10"
+PKG_VERSION="1.4.0_beta11"
+PKG_SHA256="85263762455ac92c9f5ee94f3f53adcda7b89c265829ef0a4506d3f3cc39ab73"
+PKG_REV="0~beta-11"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/dtechsrv/aml-vnc-server/"

--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/bin/aml-vnc.start
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/bin/aml-vnc.start
@@ -28,4 +28,9 @@ if [ ${AML_VNC_DEBUG} == "true" ] ; then
   export VNC_DEBUGLOG="TRUE"
 fi
 
+# Enable headless fallback only on legacy FBDEV Mali stacks
+if !(grep -q 'gbm_create_device' /usr/lib/libMali.so); then
+  export VNC_HEADLESS="TRUE"
+fi
+
 exec aml-vnc


### PR DESCRIPTION
Headless mode assumtion changed to optional in this beta, because a working solution should be found for the new (S905X5+) and older (S905X4 and earlier) SoCs as well. As I know in the case of the new SoCs, FBDEV is not actually used by Kodi.

Moreover, since headless mode does not work on newer SoCs, the mouse used over the bootsplash is actually controlling Kodi, but completely blindly, so this mode should be prevented at the system level.