### PR TITLE
wifi_dummy: add Fire TV Cube MT7668 warm reboot reset

### DIFF
--- a/projects/Amlogic-ce/packages/linux-drivers/amlogic/wifi_dummy-aml/sources/wifi_dummy.c
+++ b/projects/Amlogic-ce/packages/linux-drivers/amlogic/wifi_dummy-aml/sources/wifi_dummy.c
@@ -2,7 +2,9 @@
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/init.h>
+#include <linux/of.h>
 #include <linux/of_address.h>
+#include <linux/reboot.h>
 #include <linux/version.h>
 
 MODULE_LICENSE("GPL");
@@ -12,6 +14,10 @@ MODULE_DESCRIPTION("Amlogic WiFi power on and SDIO/PCIe rescan module");
 extern void extern_wifi_set_enable(int);
 extern void sdio_reinit(void);
 
+#define FIREFCUBE_MT7668_PMU_RESET_MS 800
+#define FIREFCUBE_MT7668_BOOT_SETTLE_MS 500
+#define FIREFCUBE_MT7668_SHUTDOWN_RESET_MS 500
+
 #undef CONFIG_PCI
 
 #ifdef CONFIG_PCI
@@ -19,6 +25,8 @@ extern void set_usb_wifi_power(int);
 extern void pci_remove(void);
 extern void pci_reinit(void);
 #endif
+
+static bool firecube_mt7668_resident;
 
 /*
       name sdio                name sdio                 name sd1          
@@ -65,10 +73,52 @@ int len;
 	return ret;
 }
 
+static bool firecube_is_2nd_gen(void)
+{
+	struct device_node *root;
+	const char *dt_id = NULL;
+	bool ret = false;
+
+	root = of_find_node_by_path("/");
+	if (!root)
+		return false;
+
+	if (!of_property_read_string(root, "coreelec-dt-id", &dt_id) &&
+	    !strcmp(dt_id, "g12b_s922z_amazon_2nd_gen_cube"))
+		ret = true;
+
+	of_node_put(root);
+	return ret;
+}
+
+static void firecube_reset_sdio_wifi(void)
+{
+	pr_info("wifi_dummy: resetting MT7668 SDIO power rail before bus rescan\n");
+	extern_wifi_set_enable(0);
+	msleep(FIREFCUBE_MT7668_PMU_RESET_MS);
+	extern_wifi_set_enable(1);
+	msleep(FIREFCUBE_MT7668_BOOT_SETTLE_MS);
+}
+
+static int firecube_mt7668_reboot_notify(struct notifier_block *nb,
+					 unsigned long action, void *data)
+{
+	pr_info("wifi_dummy: powering down MT7668 SDIO rail for warm reboot\n");
+	extern_wifi_set_enable(0);
+	msleep(FIREFCUBE_MT7668_SHUTDOWN_RESET_MS);
+
+	return NOTIFY_DONE;
+}
+
+static struct notifier_block firecube_mt7668_reboot_nb = {
+	.notifier_call = firecube_mt7668_reboot_notify,
+};
+
 static int __init wifi_dummy_init(void)
 {
 bool sdio_en = false;
 bool pcie_en = false;
+bool is_firecube = false;
 
 	pr_info("wifi_dummy: Triggered SDIO/PCIe WiFi power on and bus rescan\n");
 
@@ -87,6 +137,10 @@ bool pcie_en = false;
 		sdio_en ? "enabled" : "disabled",
 		pcie_en ? "enabled" : "disabled");
 
+	is_firecube = firecube_is_2nd_gen();
+	if (is_firecube)
+		pr_info("wifi_dummy: Fire TV Cube 2nd Gen MT7668 reset path enabled\n");
+
 #ifdef CONFIG_PCI
 	if (pcie_en) {
 		pci_remove();
@@ -95,9 +149,13 @@ bool pcie_en = false;
 #endif
 
 	if (sdio_en) {
-		extern_wifi_set_enable(0);
-		msleep(300);
-		extern_wifi_set_enable(1);
+		if (is_firecube) {
+			firecube_reset_sdio_wifi();
+		} else {
+			extern_wifi_set_enable(0);
+			msleep(300);
+			extern_wifi_set_enable(1);
+		}
 	} else {
 		msleep(300);
 	}
@@ -117,12 +175,30 @@ bool pcie_en = false;
 		pci_reinit();
 #endif
 
+	/*
+	 * Keep this helper resident on SDIO systems so a software reboot leaves
+	 * the MT7668 Wi-Fi PMU rail powered down before the next kernel probes
+	 * the combo chip.  Bluetooth stays under the normal bt-dev GPIO path; the
+	 * FireCube/CE21 device tree relies on the Wi-Fi and BT functions sharing
+	 * the vendor combo-chip initialization sequence.
+	 */
+	if (is_firecube && sdio_en) {
+		if (!register_reboot_notifier(&firecube_mt7668_reboot_nb)) {
+			firecube_mt7668_resident = true;
+			pr_info("wifi_dummy: registered MT7668 warm reboot reset notifier\n");
+			return 0;
+		}
+
+		pr_warn("wifi_dummy: failed to register MT7668 warm reboot reset notifier\n");
+	}
+
 	return -ENODEV;
 }
 
 static void __exit wifi_dummy_cleanup(void)
 {
-	/* unused */
+	if (firecube_mt7668_resident)
+		unregister_reboot_notifier(&firecube_mt7668_reboot_nb);
 }
 
 module_init(wifi_dummy_init);


### PR DESCRIPTION
## Summary

This PR is now limited to the CoreELEC-side `wifi_dummy` warm-reboot reset hook for Fire TV Cube 2nd Gen (`g12b_s922z_amazon_2nd_gen_cube`).

The hook is narrowly gated by the root DT property:

- `coreelec-dt-id = "g12b_s922z_amazon_2nd_gen_cube"`

When that DT ID is present, `wifi_dummy` stays resident so it can power down the MT7668 Wi-Fi PMU rail before software reboot and reset the rail before SDIO rescan. Other Amlogic-no devices keep the existing behavior.

## Scope notes

Removed from this PR based on review feedback:

- `SUBDEVICE`, bootloader, update, and `u-boot` changes.
- `dtb.conf` changes.
- The Fire TV Cube DTS patch, now moved to CoreELEC/common_drivers#12:
  https://github.com/CoreELEC/common_drivers/pull/12
- The MT7668 driver patch, now moved to CoreELEC/MT7668#3:
  https://github.com/CoreELEC/MT7668/pull/3

## Validation

Validated in a downstream CE22 Fire TV Cube 2nd Gen integration build on kernel 5.15.196.

Checks performed:

- `git diff --check origin/coreelec-22` passed.
- PR diff now contains only `projects/Amlogic-ce/packages/linux-drivers/amlogic/wifi_dummy-aml/sources/wifi_dummy.c`.
- Downstream build booted on the Cube and recovered `wlan0` after the warm-reboot failure path that previously required a cold power-cycle.