### PR TITLE
Amlogic: reset Dolby Vision start-decode state on seek

### DIFF
--- a/projects/Amlogic-ce/packages/mediacenter/kodi/patches/kodi-999.80-amlogic-dovi-reset-start-decode-on-seek.patch
+++ b/projects/Amlogic-ce/packages/mediacenter/kodi/patches/kodi-999.80-amlogic-dovi-reset-start-decode-on-seek.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tristan Stiller <stillertristan77@gmail.com>
+Date: Tue, 12 May 2026 00:00:00 -0500
+Subject: [PATCH] DVDVideoCodecAmlogic: reset DoVi start decode state on seek
+
+Amlogic Dolby Vision streams can stall after seeking when the bitstream
+converter continues with stale start-decode state. Preserve converter metadata
+and RPU/SPS/PPS cache, but require a fresh decode start after discontinuities
+for Dolby Vision and FEL/MEL streams.
+---
+ xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+index 767d4f9c0a..dbf21e3cc6 100644
+--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
++++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+@@ -570,6 +570,11 @@ void CDVDVideoCodecAmlogic::Reset(void)
+         m_bitstream->ResetStartDecode();
+         break;
+       default:
++        if (m_hints.hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION ||
++            m_bitstream->GetDoviElType() == ELType::TYPE_FEL ||
++            m_bitstream->GetDoviElType() == ELType::TYPE_MEL)
++          m_bitstream->ResetStartDecode();
++
+         break;
+     }
+   }
+-- 
+2.43.0


### PR DESCRIPTION
## Summary

This resets the Amlogic Dolby Vision bitstream converter's start-decode state after seek/reset discontinuities for Dolby Vision and FEL/MEL streams.

## Why

Amlogic Dolby Vision playback can stall after seeking when the converter keeps stale start-decode state across a discontinuity. The existing reset path already handles AV1 and VP9. This extends the same kind of start-decode reset to Dolby Vision/FEL/MEL while preserving the converter metadata and cached RPU/SPS/PPS state.

## Validation

Checks performed:

- Patch dry-run passed against `kodi-98ba3144f46b8e1bda4c547520b8eab998593071` source.
- `git diff --check` passed.
- Downstream test build was used for Dolby Vision/FEL playback validation on Fire TV Cube 2nd Gen.
- Long DV/FEL playback was stable in the downstream build, and seek-focused testing was used while investigating this path.

This PR intentionally contains only the codec reset behavior. It does not include AVDV process-info UI work, HDR conversion controls, or device-specific FireCube patches.
