### PR TITLE
runtime: create var paths before setup writes

### DIFF
--- a/packages/sysutils/tz/system.d/tz-data.service
+++ b/packages/sysutils/tz/system.d/tz-data.service
@@ -8,6 +8,7 @@ After=var.mount systemd-tmpfiles-setup.service
 Type=oneshot
 Environment=TIMEZONE=UTC
 EnvironmentFile=-/storage/.cache/timezone
+ExecStartPre=/bin/mkdir -p /var/run
 ExecStart=/bin/ln -sf /usr/share/zoneinfo/${TIMEZONE} /var/run/localtime
 RemainAfterExit=yes
 StartLimitInterval=0

--- a/projects/Amlogic-ce/packages/opengl-meson/scripts/libmali-overlay-setup
+++ b/projects/Amlogic-ce/packages/opengl-meson/scripts/libmali-overlay-setup
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2018-present Team CoreELEC (https://coreelec.org)
 
+mkdir -p /var/lib
+
 if grep -qE "g12a|sc2|s4" /proc/device-tree/compatible; then
     ln -sf /usr/lib/libMali.dvalin.so /var/lib/libMali.so
 elif grep -q "t7" /proc/device-tree/compatible; then


### PR DESCRIPTION
## Summary

This trims the runtime-directory hardening to the two setup paths that write directly into `/var` runtime locations:

- Ensure `/var/run` exists before `tz-data.service` links `/var/run/localtime`.
- Ensure `/var/lib` exists before `libmali-overlay-setup` creates the active `/var/lib/libMali.so` symlink.

## Scope notes

Earlier changes for ConnMan, OpenSSH, and `/run/libreelec` were removed because those paths are already covered by existing tmpfiles entries or service setup.

This PR is intentionally narrow and does not change boot ordering or add broad runtime-directory policy. It only creates the target directory immediately before each service/script writes into it.

## Validation

Checks performed:

- Verified the PR diff now contains only `tz-data.service` and `libmali-overlay-setup`.
- `git diff --check origin/coreelec-22` passed.
- Downstream CE22 integration build using these changes booted with `kodi=active`, `connman=active`, and working Wi-Fi.