### PR TITLE
nfs-utils: fix nfsrahead udev helper path

### DIFF
--- a/packages/network/nfs-utils/package.mk
+++ b/packages/network/nfs-utils/package.mk
@@ -111,6 +111,12 @@ post_makeinstall_target() {
   chmod 755 ${INSTALL}/sbin/*
   mv ${INSTALL}/sbin/* ${INSTALL}/usr/sbin
   rmdir ${INSTALL}/sbin
+
+  # nfs-utils 2.9.x installs nfsrahead under libexecdir, but its udev rule
+  # still references /usr/libexec on our target. Keep the helper and rule in
+  # agreement so bdi events do not fill boot logs with failed PROGRAM calls.
+  sed -i 's|/usr/libexec/nfsrahead|/usr/lib/nfsrahead|g' \
+    "${INSTALL}/usr/lib/udev/rules.d/99-nfs.rules"
 }
 
 post_install() {


### PR DESCRIPTION
## Summary

This fixes the installed `nfsrahead` udev helper path in the CoreELEC `nfs-utils` packaging.

`nfs-utils` 2.9.x installs `nfsrahead` under the target libdir, while the installed udev rule can still point at `/usr/libexec/nfsrahead`. This rewrites the rule to call `/usr/lib/nfsrahead`, matching where the helper is installed in the target image.

## Scope notes

The earlier version of this PR also added manual `rpc-statd` runtime path creation. That was removed because `packages/network/nfs-utils/tmpfiles.d/nfs-utils.conf` already creates:

- `/run/nfs/sm`
- `/run/nfs/sm.bak`
- `/run/nfs/rmtab`
- `/run/nfs/etab`

So this PR is now intentionally limited to the `nfsrahead` path mismatch only.

## Validation

Checks performed:

- Confirmed the existing tmpfiles config already owns the `/run/nfs` state paths.
- Confirmed the PR no longer modifies `rpc-statd.service`.
- Confirmed the remaining diff only updates the installed `99-nfs.rules` helper path from `/usr/libexec/nfsrahead` to `/usr/lib/nfsrahead`.
- `git diff --check` passed.
