### PR TITLE
Amlogic: wait for HDMI DRM connector before first window init

### DIFF
--- a/projects/Amlogic-ce/packages/mediacenter/kodi/patches/kodi-999.85-amlogic-initial-drm-settle.patch
+++ b/projects/Amlogic-ce/packages/mediacenter/kodi/patches/kodi-999.85-amlogic-initial-drm-settle.patch
@@ -1,0 +1,54 @@
+--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
++++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+@@ -169,5 +169,15 @@ void CWinSystemAmlogic::HotplugEvent()
+ {
+   m_amlDisplay->aml_init_drmDevice();
++  drmModeConnection connection;
++  int mode_count = m_amlDisplay->aml_get_display_modes_count(&connection);
++  if (connection == DRM_MODE_DISCONNECTED)
++  {
++    CLog::Log(LOGWARNING,
++      "CWinSystemAmlogic - HotplugEvent ignored while HDMI DRM connector is not ready ({:d} modes)",
++      mode_count);
++    MonitorStart();
++    return;
++  }
+   std::string preferred_mode = m_amlDisplay->aml_get_preferred_mode();
+   RESOLUTION res = static_cast<RESOLUTION>(RES_DESKTOP);
+ 
+@@ -303,16 +312,33 @@ bool CWinSystemAmlogic::InitWindowSystem()
+   drmModeConnection connection;
+   int mode_count = m_amlDisplay->aml_get_display_modes_count(&connection);
+ 
++  // Some Amlogic DRM devices can expose HDMI modes before the encoder/CRTC is
++  // fully latched on the 5.15 DRM path. Re-probe briefly here so first Kodi
++  // start does not create the GUI against dummy_l or a half-bound scanout.
++  if (connection == DRM_MODE_DISCONNECTED && mode_count > 1)
++  {
++    for (int attempt = 1; attempt <= 30 && connection == DRM_MODE_DISCONNECTED; ++attempt)
++    {
++      CLog::Log(LOGDEBUG,
++        "CWinSystemAmlogic::InitWindowSystem waiting for HDMI DRM connector bind ({:d}/30)",
++        attempt);
++      usleep(100000);
++      m_amlDisplay->aml_init_drmDevice();
++      mode_count = m_amlDisplay->aml_get_display_modes_count(&connection);
++    }
++  }
++
+   if (connection == DRM_MODE_DISCONNECTED)
+   {
+     if (mode_count > 1)
+     {
+-      CLog::Log(LOGDEBUG, "CWinSystemAmlogic::InitWindowSystem Looks like display was hotplugged before Kodi start");
+-      HotplugEvent();
++      CLog::Log(LOGWARNING,
++        "CWinSystemAmlogic::InitWindowSystem HDMI modes are present but DRM connector is not ready; wait for hotplug");
++      MonitorStart();
+     }
+     else if (mode_count == 1)
+     {
+       CLog::Log(LOGDEBUG, "CWinSystemAmlogic::InitWindowSystem Looks like no display is connected, wait for hotplug");
+       MonitorStart();
+     }
+   }

--- a/projects/Amlogic-ce/packages/mediacenter/kodi/patches/kodi-999.86-amlogic-drm-reprobe-rebind.patch
+++ b/projects/Amlogic-ce/packages/mediacenter/kodi/patches/kodi-999.86-amlogic-drm-reprobe-rebind.patch
@@ -1,0 +1,65 @@
+--- a/xbmc/windowing/amlogic/AMLDisplay.cpp
++++ b/xbmc/windowing/amlogic/AMLDisplay.cpp
+@@ -167,9 +167,6 @@ CAMLDRMUtils::CAMLDRMUtils()
+   }
+ 
+   aml_init_drmDevice();
+-
+-  if (aml_get_drmDevice_connected())
+-    aml_init_drmDevice_display();
+ }
+ 
+ CAMLDRMUtils::~CAMLDRMUtils()
+@@ -190,23 +187,43 @@ CAMLDRMUtils::~CAMLDRMUtils()
+ 
+ void CAMLDRMUtils::CleanAndClose()
+ {
+   if (m_resources)
++  {
+     drmModeFreeResources(m_resources);
++    m_resources = nullptr;
++  }
+ 
+   if (m_connector)
++  {
+     drmModeFreeConnector(m_connector);
++    m_connector = nullptr;
++  }
+ 
+   if (m_encoder)
++  {
+     drmModeFreeEncoder(m_encoder);
++    m_encoder = nullptr;
++  }
+ 
+   if (m_crtc)
++  {
+     drmModeFreeCrtc(m_crtc);
++    m_crtc = nullptr;
++  }
+ 
+   if (m_orig_crtc)
++  {
+     free(m_orig_crtc);
++    m_orig_crtc = nullptr;
++  }
+ 
+   if (m_plane)
++  {
+     drmModeFreePlane(m_plane);
++    m_plane = nullptr;
++  }
++
++  m_connection = DRM_MODE_DISCONNECTED;
+ }
+ 
+ void CAMLDRMUtils::aml_init_drmDevice()
+@@ -279,5 +298,8 @@ void CAMLDRMUtils::aml_init_drmDevice()
+     throw std::runtime_error("failed to get primary plane of drmDevice");
+   }
++
++  if (aml_get_drmDevice_connected())
++    aml_init_drmDevice_display();
+ }
+ 
+ void CAMLDRMUtils::aml_init_drmDevice_display()


### PR DESCRIPTION
## Summary

This adds a bounded Amlogic DRM settle/reprobe path before Kodi initializes the first window against HDMI.

Changes included:

- Delay first window initialization briefly when HDMI modes are visible but the DRM connector still reports disconnected.
- Avoid creating the GUI against `dummy_l` or a half-bound scanout when the HDMI encoder/CRTC has not settled yet.
- Clean DRM object pointers on reprobe and initialize display state after the connector is actually connected.
- Treat hotplug events with a disconnected connector as not-ready instead of forcing a bad mode selection.

## Why

On a CE22 / kernel 5.15 Amlogic-no test build, Kodi could start while HDMI modes existed but the DRM connector was still reported disconnected. In the bad path Kodi fell through into an invalid first GUI/display state. Waiting briefly for the connector/encoder to bind avoids that first-start race without inventing fake connector or CRTC state.

## Scope notes

This is not FireCube-specific in the code or comments. The issue was observed on a Fire TV Cube 2nd Gen downstream build, but the fix is framed as a generic Amlogic DRM initialization race because the failure mode is in the Amlogic HDMI DRM/Kodi window initialization path.

## Validation

Checks performed:

- Both Kodi patch files dry-run cleanly against `kodi-98ba3144f46b8e1bda4c547520b8eab998593071` source.
- `git diff --check` passed.
- The downstream integration build using this behavior booted to Kodi without the previous first-start display failure.
- The deployed test build reported `kodi=active`, `connman=active`, and working network after boot.

This PR is separated from FireCube device-tree work and AVDV UI work so the DRM behavior can be reviewed independently.
