### PR TITLE
aml-vnc: bump package to 1.4.0_beta13

### DIFF
--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/changelog.txt
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/changelog.txt
@@ -1,5 +1,5 @@
 22.0.0
-- bump package to 1.4.0_beta11
+- bump package to 1.4.0_beta13
 - change addon icon
 - add new config options
 

--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/package.mk
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team CoreELEC (https://coreelec.org)
 
 PKG_NAME="aml-vnc"
-PKG_VERSION="1.4.0_beta11"
-PKG_SHA256="85263762455ac92c9f5ee94f3f53adcda7b89c265829ef0a4506d3f3cc39ab73"
-PKG_REV="0~beta-11"
+PKG_VERSION="1.4.0_beta13"
+PKG_SHA256="a550664bec9911563ca2d96bd5ef616fdac2f34b730eb14d5cdd6d41e7d4e6b9"
+PKG_REV="0~beta-13"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/dtechsrv/aml-vnc-server/"

--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/bin/aml-vnc.start
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/source/bin/aml-vnc.start
@@ -28,9 +28,8 @@ if [ ${AML_VNC_DEBUG} == "true" ] ; then
   export VNC_DEBUGLOG="TRUE"
 fi
 
-# Enable headless fallback only on legacy FBDEV Mali stacks
-if !(grep -q 'gbm_create_device' /usr/lib/libMali.so); then
-  export VNC_HEADLESS="TRUE"
+if !(grep -F -q 'gbm_create_device' /usr/lib/libMali.so); then
+  export VNC_FORCEFBDEV="TRUE"
 fi
 
 exec aml-vnc


### PR DESCRIPTION
**Changes:**
https://github.com/dtechsrv/aml-vnc-server/compare/1.4.0_beta11...1.4.0_beta13

Due to switch to dual framebuffer in the S7D DRM implementation (and probably also under S5 and S6), the detection of the current buffer was modified on server side as well, because in the case of a resolution or frequency change, it often did not detect and use the right source buffer that was really used for the capture, which produced blank screen. _(I don't know when the DRM stack was changed, but the framebuffer pairs didn't exist two months ago, so it gave me a bit of a headache over this weekend.)_

In addition, I replaced the assumption of headless mode with forced use of FBDEV for older SoCs, which is usually much better solution here than using the DRM backend directly.

