### PR TITLE
kodi: add backport patch to fix subtitle extradata discarded in CDVDDemuxClient

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-999.40-PR28362-backport-fix-subtitle-extradata.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.40-PR28362-backport-fix-subtitle-extradata.patch
@@ -1,0 +1,57 @@
+From 8cf941bb01a02b95f842866b4660132312f084b6 Mon Sep 17 00:00:00 2001
+From: GenkaiToppa <om@tatipamula.com>
+Date: Sat, 23 May 2026 15:14:33 -0400
+Subject: [PATCH] VideoPlayer: don't discard subtitle extradata in
+ CDVDDemuxClient
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The subtitle branch of CDVDDemuxClient::SetStreamProps gates the
+extradata copy on `extraData.GetSize() == 4`, silently discarding
+extradata of any other size. ASS/SSA script headers are several
+kilobytes long, so they are dropped, and CDVDOverlayCodecSSA::Open
+later fails with "Unable to init overlay codec" for every InputStream
+addon that delivers rich subtitles.
+
+The 4-byte gate is a PVR/DVB-subtitle identifier hack that outgrew its
+original scope:
+
+  * 27d94da7 (2013, elupus) "livetv: dvb subtitle identifiers should
+    be written big endian" introduced a 4-byte DVB subtitle id in the
+    PVR-only demuxer. Correct in context: the path was PVR-only and
+    the only subtitle extradata flowing through it was that 4-byte id.
+
+  * 016e5f58 (2016, fernetmenta) "VideoPlayer: refactor DemuxerClient
+    (ex PVR)" generalized the PVR demuxer into DVDDemuxClient for all
+    InputStream addons, and carried the `ExtraSize == 4` check along.
+    A PVR-only assumption became a universal rule: any subtitle
+    extradata that isn't exactly 4 bytes is dropped.
+
+  * e5922ff2 (2023, Markus Härer) "FFmpeg: Handle FFmpeg extradata in
+    dedicated class" modernized the gate to the FFmpegExtraData API
+    but preserved the `== 4` check verbatim.
+
+Align the subtitle branch with the audio and video branches above,
+which copy extradata whenever it is non-empty. The 4-byte DVB
+identifier still satisfies this condition, so PVR is unaffected.
+---
+ xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+index 0cdf8c3864..7fdbeac652 100644
+--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
++++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+@@ -519,7 +519,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
+         streamSubtitle->m_parser->flags |= PARSER_FLAG_COMPLETE_FRAMES;
+     }
+ 
+-    if (source->extraData.GetSize() == 4)
++    if (source->extraData)
+     {
+       streamSubtitle->extraData = source->extraData;
+     }
+-- 
+2.54.0
+


### PR DESCRIPTION
Adds the one-line fix from [xbmc#28362](https://github.com/xbmc/xbmc/pull/28362) (currently open against Kodi master; an Omega cherry-pick PR will follow).

`CDVDDemuxClient::SetStreamProps` silently drops every subtitle stream's `extradata` unless it is exactly 4 bytes. ASS/SSA script headers are several kilobytes long, so they are always dropped, and `CDVDOverlayCodecSSA::Open` fails with `Unable to init overlay codec` for every InputStream addon that delivers rich subtitles. The same code is present in 21.x at line 522. The patch replaces the size-equality gate with the same non-empty check the audio and video branches already use. The 4-byte DVB-subtitle identifier still passes, so PVR is unaffected.

Reproduced and fixed in a local Kodi 21.2-Omega build. Stock: error and no subtitles render. Patched: `CDVDSubtitlesLibass: Creating new ASS track`, ASS renders correctly.

Can be dropped once the Omega cherry-pick has been merged and kodi is bumped past it in CoreELEC.
