### PR TITLE
kernel-firmware: add rtl_nic/* to base whitelist

### DIFF
--- a/packages/linux-firmware/kernel-firmware/firmwares/any.dat
+++ b/packages/linux-firmware/kernel-firmware/firmwares/any.dat
@@ -20,6 +20,7 @@ ath6k/AR6004/hw1.?/bdata.bin
 ath9k_htc/*
 brcm/*
 rtl_bt/*
+rtl_nic/*
 rtlwifi/*
 rtw88/*
 rtw89/*


### PR DESCRIPTION
The Realtek wired-ethernet firmware dir was missing from any.dat even though its wifi/bt siblings are there, so r8152 can't bind any firmware out of the box. Tested on AM6B+ with USB 2.5G adapter. Driver loads and the link comes up at 2.5 Gbit with no missing firmware issue.