### PR TITLE
AVL6862: install firmware files

### DIFF
--- a/projects/Amlogic-ce/packages/linux-driver-addons/dvb/AVL6862/package.mk
+++ b/projects/Amlogic-ce/packages/linux-driver-addons/dvb/AVL6862/package.mk
@@ -29,4 +29,7 @@ make_target() {
 
 makeinstall_target() {
   install_driver_addon_files "${PKG_BUILD}"
+
+  mkdir -p ${INSTALL}/$(get_full_firmware_dir $PKG_ADDON_ID)
+  cp -r ${PKG_BUILD}/firmware/* ${INSTALL}/$(get_full_firmware_dir $PKG_ADDON_ID)/
 }


### PR DESCRIPTION
required for avl62x1 driver added in this PR:
https://github.com/CoreELEC/media_tree_aml/pull/8