### PR TITLE
aml-vnc: bump package to 1.4.0_beta16

### DIFF
--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/changelog.txt
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/changelog.txt
@@ -1,5 +1,5 @@
 22.0.0
-- bump package to 1.4.0_beta15
+- bump package to 1.4.0_beta16
 - change addon icon
 - add new config options
 

--- a/projects/Amlogic-ce/packages/addons/service/aml-vnc/package.mk
+++ b/projects/Amlogic-ce/packages/addons/service/aml-vnc/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team CoreELEC (https://coreelec.org)
 
 PKG_NAME="aml-vnc"
-PKG_VERSION="1.4.0_beta15"
-PKG_SHA256="2b297d69aa57aabe3e9d8622135b9bad1789e736735c94bb9c18730aad702558"
-PKG_REV="0~beta-15"
+PKG_VERSION="1.4.0_beta16"
+PKG_SHA256="e8bac94733f7146f2ff9bbe6d5c7be68dab931f3379fa0249966b44bea83e3a9"
+PKG_REV="0~beta-16"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/dtechsrv/aml-vnc-server/"


### PR DESCRIPTION
**Changes:**
https://github.com/dtechsrv/aml-vnc-server/compare/1.4.0_beta15...1.4.0_beta16

**In more detail:**
- https://github.com/dtechsrv/aml-vnc-server/commit/6ca621b3a9b2ac16e30d1ad9ba300ec7f4d91b2e:
There was a Kodi issue (https://github.com/xbmc/xbmc/issues/28405) that I finally resolved on the VNC server side. This doesn't affect CE for now, but if you later switch to using D2P, the VNC server can handle it and bypass the primary plane containing the UI/OSD masked by Kodi during video playback.
- https://github.com/dtechsrv/aml-vnc-server/commit/53e2d78d05832263dde8b330b8fe588e3579a71a:
The server automatically exits if it detects that the framebuffer is using a non-linear modifier (e.g. AFBC) because its processing is not implemented. This does not affect CE for now, but if you plan to introduce a similar feature in the future, it will probably not be possible on the VNC side because software decoding of these is highly CPU-intensive.
- https://github.com/dtechsrv/aml-vnc-server/commit/c681f6520db74e8f308a2d0848c4287e082de566:
Also, the idle logic has been reworked, and an old legacy method has been banished. Now, if there is no change between two consecutive frames, it will not check for changes during the next 3 frames, thereby reducing CPU load. The previous solution was similar, but used constant values, and add an idle cycle even when it was not needed, and also affected the event handling cycle, which is now completely continuous.

I'm at the end of my current ToDo list, so if there are no bug reports or new feature requests after this, v1.4.0 will be finalized soon.