### PR TITLE
Fixed wrong aspect ratio of htab and hsbs videos

### DIFF
--- a/projects/Amlogic-ce/packages/mediacenter/kodi/patches/01-use_correct_ratio_for_htab_and_hsbs.patch
+++ b/projects/Amlogic-ce/packages/mediacenter/kodi/patches/01-use_correct_ratio_for_htab_and_hsbs.patch
@@ -1,0 +1,26 @@
+diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+index f6392fd3fd..4424ddebab 100644
+--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
++++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+@@ -1509,9 +1509,19 @@ double CDVDDemuxFFmpeg::SelectAspect(AVStream* st, bool& forced)
+     if (entry)
+     {
+       if (strcmp(entry->value, "left_right") == 0 || strcmp(entry->value, "right_left") == 0)
+-        dar /= (st->codecpar->width / 1920.0);
++      {
++        if (st->codecpar->width > 1920)
++          dar /= (st->codecpar->width / 1920.0);
++        else
++          dar /= 2;
++      }
+       else if (strcmp(entry->value, "top_bottom") == 0 || strcmp(entry->value, "bottom_top") == 0)
+-        dar *= (st->codecpar->height / 1080.0);
++      {
++        if (st->codecpar->height > 1080)
++          dar *= (st->codecpar->height / 1080.0);
++        else
++          dar *= 2;
++      }
+     }
+     return dar;
+   }


### PR DESCRIPTION
A long time ago a patch has been indroduced which fixed the aspect ratio of full sbs/tab videos. But as a regression the aspect ratio of half sbs/tab videos was wrong.  All FSBS videos have a width > 1920 and all FTAB videos have a height > 1080. 
So if ```st->codecpar->width``` of an SBS video is <= 1920, then it's HSBS and if ```st->codecpar->height``` of a TAB video is <= 1920 then it's HTAB.
This patch restores the old behaviour for HSBS/HTAB videos while FSBS/FTAB videos continue to work correctly.