### PR TITLE
mt7612u: add new linux driver

### DIFF
--- a/projects/Amlogic-ce/devices/Amlogic-ng/options
+++ b/projects/Amlogic-ce/devices/Amlogic-ng/options
@@ -111,7 +111,7 @@
     ADDITIONAL_DRIVERS+=" RTL8192CU RTL8192DU RTL8192EU RTL8188EU RTL8821CU
                         ssv6xxx-aml mt7668-wifi-bt RTL8188FTV-aml RTL8189ES-aml RTL8189FS-aml
                         RTL8723BS-aml RTL8822BS-aml RTL8821CS-aml qca9377-aml
-                        qca6174-aml smartchip"
+                        qca6174-aml smartchip mt7612u"
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,

--- a/projects/Amlogic-ce/packages/linux-drivers/amlogic/mt7612u/package.mk
+++ b/projects/Amlogic-ce/packages/linux-drivers/amlogic/mt7612u/package.mk
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2026-present Team CoreELEC (https://coreelec.org)
+#
+# MediaTek MT7612U (RT28xx/RT2870 STA lineage) USB Wi-Fi driver.
+# Source: caruofc/MT7612U-Driver (4.9/ARM64-patched MediaTek RT28xx STA fork).
+#
+# Build-tested: `PROJECT=Amlogic-ce DEVICE=Amlogic-ng ARCH=arm ./scripts/build
+# mt7612u` produces os/linux/mt7612u.ko (ELF aarch64, vermagic
+# "4.9.269 SMP preempt mod_unload modversions aarch64", alias usb:v0E8Dp7612)
+# and installs it to lib/modules/<kver>/mt7612u/.
+
+PKG_NAME="mt7612u"
+PKG_VERSION="749e6fd1a559e454b17ae91959fe07d6ef58e6af"
+PKG_SHA256="a4e3a6652e48bb521ec6b1141ad5d52aeff6d0c3b0097d3ef48808f967203bf1"
+PKG_ARCH="arm aarch64"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/caruofc/MT7612U-Driver"
+PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_NEED_UNPACK="${LINUX_DEPENDS}"
+PKG_LONGDESC="MediaTek MT7612U USB Wi-Fi STA driver (caruofc fork)"
+PKG_IS_KERNEL_PKG="yes"
+PKG_TOOLCHAIN="manual"
+
+pre_make_target() {
+  unset LDFLAGS
+}
+
+make_target() {
+  # caruofc is an RT28xx two-stage build: its OWN top Makefile generates
+  # mt76x2_version.h, copies os/linux/Makefile.6, and sets the -I include paths,
+  # THEN recurses into the kernel build via LINUX_SRC. Do NOT use kernel_make
+  # (make -C <kernel> M=<pkg>) — that bypasses the prep and the compile fails
+  # with "rt_config.h / mt76x2_version.h: No such file or directory".
+  make -C ${PKG_BUILD} \
+    WIFI_MODE=STA \
+    ARCH=${TARGET_KERNEL_ARCH} \
+    CROSS_COMPILE=${TARGET_KERNEL_PREFIX} \
+    LINUX_SRC=$(kernel_path)
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/$(get_full_module_dir)/${PKG_NAME}
+  cp ${PKG_BUILD}/os/linux/mt7612u.ko ${INSTALL}/$(get_full_module_dir)/${PKG_NAME}
+
+  # FIRMWARE: held back from PR #1 pending maintainer policy (see PR body).
+  # If maintainers approve shipping the blobs in the driver package, add:
+  #   mkdir -p ${INSTALL}/$(get_full_firmware_dir)
+  #   cp ${PKG_BUILD}/mcu/bin/mt7662_patch_e3_hdr.bin      ${INSTALL}/$(get_full_firmware_dir)
+  #   cp ${PKG_BUILD}/mcu/bin/mt7662_firmware_e3_tvbox.bin ${INSTALL}/$(get_full_firmware_dir)
+}


### PR DESCRIPTION
## linux-drivers: add mt7612u (MediaTek MT7612U USB Wi-Fi, STA)

### What
Adds `projects/Amlogic-ce/packages/linux-drivers/amlogic/mt7612u`, building
caruofc's RT28xx-lineage MT7612U STA driver, and enables it for Amlogic-ng via
`ADDITIONAL_DRIVERS+=`. This gives out-of-the-box Wi-Fi for MT7612U dongles
(e.g. Alfa **AWUS036ACM**, USB `0e8d:7612`) on Amlogic-ng / kernel 4.9.

### Why this driver (not mainline mt76x2u)
On the Amlogic legacy 4.9 vendor kernel, mainline `mt76x2u` is a dead end:
- Amlogic-ng has **no `MT76` kernel config at all** (grep `MT76` across all
  Amlogic-ng configs returns nothing), and the built-in `mac80211` ABI is too
  old for the out-of-tree `mt76` stack.
- mainline `mt76`/`mt76x2u` requires kernel **>= 4.19**; Amlogic-ng is 4.9.
- The "just use Amlogic-ne" path doesn't apply: Amlogic-ne (which *does* carry
  MT76 configs) supports only T7/SC2/S4 — **S922X is not supported there** — so
  the AM6B+ runs Amlogic-ng (4.9) only. There is no mainline path on the image
  this device actually runs.

This mirrors what @vpeter noted on record (CoreELEC forums, 2022-08-29,
"Looking for users with no working WiFi or BT"): the Amlogic 4.9 kernel "must
[have an] external package for it." This PR is that external package.

`ermito/mt7612u` fails to compile on 4.9 (`testmode_cmd` signature);
**caruofc/MT7612U-Driver** is a 4.9/ARM64-patched fork that builds and runs.

### How it's modeled
Modeled on the in-tree **MediaTek** precedent
`projects/Amlogic-ce/packages/linux-drivers/amlogic/mt7668-wifi-bt`
(same vendor family, out-of-tree, `kernel_make`, `PKG_TOOLCHAIN="manual"`),
and on the Realtek USB-WiFi packages (newest `RTL8851BU`, Nov 2024, which itself
carries an explicit Amlogic compile-fix patch).

**Build-hook note (important — please don't "simplify" it into a breakage):**
caruofc is an RT28xx two-stage build — its own top-level Makefile generates
`mt76x2_version.h`, copies `os/linux/Makefile.6`, and sets the `-I` include
paths, then recurses into the kernel build via **`LINUX_SRC`**. So `make_target`
invokes caruofc's Makefile directly:
`make -C ${PKG_BUILD} WIFI_MODE=STA ARCH=${TARGET_KERNEL_ARCH} CROSS_COMPILE=${TARGET_KERNEL_PREFIX} LINUX_SRC=$(kernel_path)`
— **not** `kernel_make` / `make -C <kernel> M=<pkg>`, which bypasses that prep
and fails on `rt_config.h: No such file`. Output is `os/linux/mt7612u.ko`.

### What was tested
- **This package builds via `PROJECT=Amlogic-ce DEVICE=Amlogic-ng ARCH=arm
  ./scripts/build mt7612u`** in CoreELEC's own `noble` builder: produces
  `os/linux/mt7612u.ko` and installs it to `lib/modules/4.9.269/mt7612u/`
  (ELF aarch64, alias `usb:v0E8Dp7612`).
- `vermagic = 4.9.269 SMP preempt mod_unload modversions aarch64` (matches the
  running kernel).
- Hardware: **Ugoos AM6B+ (Amlogic S922X-J), CoreELEC 21.3-Omega** — the same
  driver (built identically, caruofc Makefile + `LINUX_SRC`) brings `wlan1` up on
  **5 GHz with DHCP**; wired remains primary. Stable across reboot.

### Firmware (open question for maintainers)
This PR ships **no firmware blob** — I want your call on policy first.

The driver loads a ROM patch + main firmware at probe. The caruofc tree carries
`mt7662_patch_e3_hdr.bin` + `mt7662_firmware_e3_tvbox.bin` (the exact 2016
MediaTek TV-box blobs that worked on the AM6B+ in testing). I verified a full
recursive grep of the 21.3-Omega tree for `mt7662|mt76x|mt76|mt7612|mediatek`
returns **zero** files, so **nothing in CoreELEC currently provides MT76xx
firmware** and there is **no collision risk** either way.

Options, in your preference:
  (a) add a firmware copy step to this package's `makeinstall_target`
      (`cp mcu/bin/mt7662_*_e3_*.bin -> $(get_full_firmware_dir)`); or
  (b) add the upstream linux-firmware redistributable `mediatek/mt7662.bin` +
      `mediatek/mt7662_rom_patch.bin` to a `kernel-firmware*.dat` and a tiny
      patch repointing the driver's requested filename to the mainline name.

I'm happy to implement whichever you prefer re: MediaTek redistributable-blob
policy. (The e3 blobs have no explicit license file in the caruofc repo; the
upstream linux-firmware files are explicitly Redistributable + patent-granted.)

### Credits / license
Driver © MediaTek / Ralink RT28xx lineage; 4.9/ARM64 fork by **caruofc**;
`PKG_LICENSE="GPL"`. I'll maintain this across kernel bumps.

---
Branch off `coreelec-21`, single squashed commit, no `Signed-off-by` (house style).
