### PR TITLE
Amlogic-no: enable CONFIG_AMLOGIC_DSC

### DIFF
--- a/projects/Amlogic-ce/devices/Amlogic-no/linux/linux.aarch64.conf
+++ b/projects/Amlogic-ce/devices/Amlogic-no/linux/linux.aarch64.conf
@@ -6511,7 +6511,7 @@ CONFIG_AMLOGIC_HDMITX_COMMON=y
 #
 # Amlogic DSC_ENCODER Module
 #
-# CONFIG_AMLOGIC_DSC is not set
+CONFIG_AMLOGIC_DSC=y
 # end of Amlogic DSC_ENCODER Module
 
 #


### PR DESCRIPTION
## Summary

8K modes that exceed plain (non-DSC) FRL bandwidth at full chroma/bit depth
were being rejected outright instead of falling back to DSC.
`CONFIG_AMLOGIC_DSC` was unset for the `Amlogic-no` device, which compiles
out both the `drivers/media/vout/dsc/` DSC encoder driver entirely and the
DSC fallback branch in `hdmitx_edid_validate_format_para()` (falls straight
to `#else return -EPERM;`), so `meson_hdmitx_encoder_atomic_check()` rejects
the mode with no retry attempted.

This enables the kernel option so the existing (already-compiled-in) DSC
negotiation path can actually run.

## Test plan

Confirmed via dmesg on a Ugoos SK1 (Amlogic S928X-K):

- **Before**: `7680x4320p60hz` fails validation
  (`*HDMITX_ERROR* validate formatpara [7680x4320p60hz,444,10bit] return
  error -1`, `*ERROR* validate_mode fail`) and the HDMI link silently stays
  at 4K60 instead.
- **After** (this change): the same mode negotiates cleanly via DSC (FRL3
  link training, 8x2 slice `DSC_YUV444_7680X4320_60HZ` configuration), and
  the downstream display chain confirms a genuine 8K60 4:4:4 10-bit signal
  is actually being transmitted (not just requested).
- [x] Clean 8K60 mode-set, zero kernel errors, confirmed via dmesg
- [x] Confirmed on real downstream hardware (HDMI signal analyzer + display)
      that the negotiated 8K60 4:4:4 10-bit signal is genuinely present
- [ ] Not tested on other 8K-capable Amlogic-ce devices — this only touches
      the `Amlogic-no` device config, so it's a no-op elsewhere