### PR TITLE
mbedtls: bump package to 3.6.7

### DIFF
--- a/projects/Amlogic-ce/packages/addons/addon-depends/mbedtls/package.mk
+++ b/projects/Amlogic-ce/packages/addons/addon-depends/mbedtls/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team CoreELEC (https://coreelec.org)
 
 PKG_NAME="mbedtls"
-PKG_VERSION="3.6.6"
-PKG_SHA256="8fb65fae8dcae5840f793c0a334860a411f884cc537ea290ce1c52bb64ca007a"
+PKG_VERSION="3.6.7"
+PKG_SHA256="a7e8bcbec0e6f761b4af24f25677626b35f762f68eef79c08677a363212d11f6"
 PKG_LICENSE="Apache 2.0"
 PKG_SITE="https://github.com/Mbed-TLS/mbedtls"
 PKG_URL="https://github.com/Mbed-TLS/mbedtls/releases/download/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
Bumps the CE-local mbedtls addon dependency from 3.6.6 to 3.6.7 (released 2026-07-07).

**Release:** https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.7

**Security fixes in 3.6.7:**
- Timing side-channel in RSA PKCS#1 v1.5 decryption
- Extended master secret calculation failure ignored

Patch-version bump within the 3.6 LTS line. `mbedtls` is a CE-local addon dependency (no LibreELEC equivalent) consumed only by `hyperion.ng`. SHA256 verified against the downloaded tarball.