### PR TITLE
aml-dtbtools: bump package to b2ca13ce

### DIFF
--- a/projects/Amlogic-ce/packages/tools/aml-dtbtools/package.mk
+++ b/projects/Amlogic-ce/packages/tools/aml-dtbtools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team CoreELEC (https://coreelec.org)
 
 PKG_NAME="aml-dtbtools"
-PKG_VERSION="cce100f"
-PKG_SHA256="8bcaa83fcc9e85c9c04930e7411447d96a97da0809c5ecd9af91c8b554133c41"
+PKG_VERSION="b2ca13ce06627d4e38b3fce56d7aadf077b7bc7d"
+PKG_SHA256="12b8cd2c5909aca2a39f743129ea428ab05601350699e4804aec5ef42fcd24ab"
 PKG_LICENSE="free"
 PKG_SITE="https://github.com/Wilhansen/aml-dtbtools"
 PKG_URL="https://github.com/Wilhansen/aml-dtbtools/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Bumps the CE-local aml-dtbtools build tool (dtbTool/dtbSplit) from `cce100f` to `b2ca13ce`.

Two upstream commits:
- `b2ca13ce` Add missing header for Linux compilation
- `557fde5e` Minor formatting fix

Also switches `PKG_VERSION` to the full 40-char revision per the project's STANDARDS.md (`cce100f` was a grandfathered short hash). SHA256 verified against the downloaded tarball.