### PR TITLE
openvfd-driver: bump package to 6de4e217

### DIFF
--- a/projects/Amlogic-ce/packages/linux-drivers/openvfd-driver/package.mk
+++ b/projects/Amlogic-ce/packages/linux-drivers/openvfd-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Arthur Liberman (arthur_liberman@hotmail.com)
 
 PKG_NAME="openvfd-driver"
-PKG_VERSION="3118dda3aeb5b2f02b0ac0b5d30cbef58947a805"
-PKG_SHA256="fd0f38d059536e30000d3e2de3802ee97f8eeb7aac74143f0e588f803921a5ad"
+PKG_VERSION="6de4e217ba7bf67b9cd813629389a645e27e4674"
+PKG_SHA256="4d2956e2814fb21aa075bc6c1442151f807595fd27111ffc171a6262c12f661d"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/arthur-liberman/linux_openvfd"
 PKG_URL="https://github.com/arthur-liberman/linux_openvfd/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
Bumps the CE-local openvfd-driver (VFD display kernel module + OpenVFDService) from `3118dda3` to `6de4e217` (upstream v1.4.5).

16 upstream commits. Highlights relevant to CoreELEC's 5.15 kernel:
- **`1412411a` openvfd_drv: fix build warnings on 5.15 kernel** (landed *after* the 6.7/6.12 API changes, so 5.15 was re-validated)
- `9455fc1b` controllers: fd628, fd650 - fix `set_display_type` input validation
- `1191aba8` openvfd_drv: probe mutex guard, write errno, dots, debug append
- `bcd7db7d` Service: fix snprintf format and string_main buffer sizes
- `4cbd7725` expose brightness control to userspace driver attrs
- kernel 6.7.0 and 6.12 API compatibility (version-guarded)

CE-specific scripts and `openvfd.conf.d` are untouched (they live in the package dir, not upstream). SHA256 verified against the downloaded tarball.