### PR TITLE
Add script.module.sidedata addon package

### DIFF
--- a/projects/Amlogic-ce/packages/addons/script/sidedata/package.mk
+++ b/projects/Amlogic-ce/packages/addons/script/sidedata/package.mk
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026-present Team CoreELEC (https://coreelec.org)
+
+PKG_NAME="sidedata"
+PKG_VERSION="1.4.2"
+PKG_SHA256="ff29fc42b7c1f1a2366a93a8434761ded93a049ad41bd0c94e3d78b72a2d6b4f"
+PKG_REV="0"
+PKG_ARCH="aarch64"
+PKG_LICENSE="GPL-2.0-or-later"
+PKG_SITE="https://github.com/matthane/script.module.sidedata"
+PKG_URL="https://github.com/matthane/script.module.sidedata/archive/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_SECTION="script.module"
+PKG_SHORTDESC="Per frame video metadata for CoreELEC 22"
+PKG_LONGDESC="Reads the raw video metadata CoreELEC 22 publishes frame by frame during playback. Addons get it as a plain dict, skins get it as Home window properties."
+PKG_TOOLCHAIN="manual"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_NAME="Sidedata"
+PKG_ADDON_TYPE="xbmc.python.module"
+
+addon() {
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}
+  cp -PR ${PKG_BUILD}/* ${ADDON_BUILD}/${PKG_ADDON_ID}
+}


### PR DESCRIPTION
This packages the add-on side of CoreELEC/xbmc#68. The module parses the raw payloads from Player.Process(video.sidedata) into python fields for addons, and a service in the same addon republishes them as Home window properties for skins.

The package pulls a tarball of https://github.com/matthane/script.module.sidedata pinned by commit SHA, following the script.config.vdr pattern. The pinned commit is the v1.4.2 release, so future updates would be small PRs bumping the SHA and hash.

For RPU parsing the module bundles an aarch64 libdovi build, since the image links libdovi statically into Kodi and there is nothing shared to open at runtime. If a bundled binary is not wanted here, the package could instead build it from the same dovi_tool source the libdovi package pins, and I can rework it that way.

The zip out of create_addon carries the same content as the release zip I have been running on my box, plus your fanart and the PKG_REV version. The field reference for consumers is FIELDS.md, which ships inside the addon.
