### PR TITLE
sidedata: bump package to 1.4.3

### DIFF
--- a/projects/Amlogic-ce/packages/addons/script/sidedata/package.mk
+++ b/projects/Amlogic-ce/packages/addons/script/sidedata/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2026-present Team CoreELEC (https://coreelec.org)
 
 PKG_NAME="sidedata"
-PKG_VERSION="1.4.2"
-PKG_SHA256="ff29fc42b7c1f1a2366a93a8434761ded93a049ad41bd0c94e3d78b72a2d6b4f"
+PKG_VERSION="1.4.3"
+PKG_SHA256="078729b0a5cd1d4b40f8f86c10bd5714f6aefaf5f85d8b4c1bed662dc6080fa8"
 PKG_REV="0"
 PKG_ARCH="aarch64"
 PKG_LICENSE="GPL-2.0-or-later"


### PR DESCRIPTION
Updates the sidedata addon to v1.4.3. The bundled libdovi moves from 3.3.1 to 3.4.0 and is now built with upstream's release-deploy profile, matching quietvoid's official binaries. Parser output is unchanged and the addon was tested on device.