### PR TITLE
sidedata: bump package to 1.7.0

### DIFF
--- a/projects/Amlogic-ce/packages/addons/script/sidedata/package.mk
+++ b/projects/Amlogic-ce/packages/addons/script/sidedata/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2026-present Team CoreELEC (https://coreelec.org)
 
 PKG_NAME="sidedata"
-PKG_VERSION="1.6.0"
-PKG_SHA256="e479f2b21f5ab68f715af48581ffbe0480d49d2732d1e572ce8b3c5c5abd0d24"
+PKG_VERSION="1.7.0"
+PKG_SHA256="c0132958444cd93ced366a24f9b9d6e4d427493944b1e9895830401e1e16ccd7"
 PKG_REV="0"
 PKG_ARCH="aarch64"
 PKG_LICENSE="GPL-2.0-or-later"


### PR DESCRIPTION
Updates the sidedata addon to v1.7.0, which adds a decoder for the display's Dolby Vision VSVDB. Addons can get the decoded fields from the module and the bundled service publishes them as window properties for skins, next to the playback side data it already publishes. **The raw block is read from the VSVDB line of the dv_cap sysfs node**, so if the planned move from sysfs to DRM properties ends up changing that line, a heads up here or on the addon repo would be appreciated and I will adapt the read accordingly. Existing fields are untouched and the addon was tested on device.